### PR TITLE
feat: Transaction History from Horizon API (closes #14)

### DIFF
--- a/apps/web/app/activity/page.tsx
+++ b/apps/web/app/activity/page.tsx
@@ -4,17 +4,29 @@ import { useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { useWallet } from "@/lib/wallet-context"
 import { useI18n } from "@/lib/i18n-context"
+import { useHorizonPayments } from "@/hooks/useHorizonPayments"
 import { Sidebar } from "@/components/sidebar"
 import { DashboardHeader } from "@/components/dashboard-header"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { ArrowLeft, ShoppingCart, Send } from "lucide-react"
+import { ArrowLeft, ShoppingCart, Send, ArrowDownLeft, ArrowUpRight, Loader2, AlertCircle } from "lucide-react"
 import Link from "next/link"
 
+function formatDate(isoString: string): string {
+  const date = new Date(isoString)
+  return date.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })
+}
+
+function formatTime(isoString: string): string {
+  const date = new Date(isoString)
+  return date.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })
+}
+
 export default function ActivityPage() {
-  const { isConnected } = useWallet()
+  const { isConnected, address } = useWallet()
   const { t } = useI18n()
   const router = useRouter()
+  const { payments, isLoading, error, refetch } = useHorizonPayments(address)
 
   useEffect(() => {
     if (!isConnected) {
@@ -33,12 +45,13 @@ export default function ActivityPage() {
       <main className="md:ml-64">
         <DashboardHeader />
 
-        <div className="p-4 md:p-6">
-          <Button onClick={() => router.push("/dashboard")} variant="ghost" className="mb-4 hover:bg-muted">
+        <div className="p-4 md:p-6 space-y-6">
+          <Button onClick={() => router.push("/dashboard")} variant="ghost" className="mb-2 hover:bg-muted">
             <ArrowLeft className="w-4 h-4 mr-2" />
             {t("common.back")}
           </Button>
 
+          {/* Navigation cards */}
           <div className="grid gap-6 md:grid-cols-2">
             <Link href="/activity/purchases">
               <Card className="hover:bg-muted/50 transition-all cursor-pointer h-full group border-2 hover:border-primary">
@@ -78,6 +91,75 @@ export default function ActivityPage() {
               </Card>
             </Link>
           </div>
+
+          {/* Recent payments from Horizon */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-xl">{t("activity.recentPayments")}</CardTitle>
+              <CardDescription>{t("activity.recentPaymentsDescription")}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {isLoading ? (
+                <div className="flex items-center justify-center py-8 text-muted-foreground">
+                  <Loader2 className="w-5 h-5 mr-2 animate-spin" />
+                  {t("activity.loading")}
+                </div>
+              ) : error ? (
+                <div className="flex flex-col items-center gap-3 py-8 text-muted-foreground">
+                  <div className="flex items-center gap-2 text-destructive">
+                    <AlertCircle className="w-5 h-5" />
+                    <span>{t("activity.errorFetching")}</span>
+                  </div>
+                  <Button variant="outline" size="sm" onClick={refetch}>
+                    {t("activity.retry")}
+                  </Button>
+                </div>
+              ) : payments.length === 0 ? (
+                <div className="text-center py-8 text-muted-foreground">{t("activity.noTransactions")}</div>
+              ) : (
+                <div className="space-y-3">
+                  {payments.slice(0, 10).map((payment) => {
+                    const isIncoming = payment.to === address
+                    const assetLabel =
+                      payment.asset_type === "native"
+                        ? "XLM"
+                        : payment.asset_code ?? payment.asset_type
+
+                    return (
+                      <div
+                        key={payment.id}
+                        className="flex items-center gap-3 p-4 rounded-lg hover:bg-muted transition-colors border border-border"
+                      >
+                        <div className="flex-shrink-0">
+                          {isIncoming ? (
+                            <ArrowDownLeft className="w-5 h-5 text-success" />
+                          ) : (
+                            <ArrowUpRight className="w-5 h-5 text-primary" />
+                          )}
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <p className="font-medium text-sm md:text-base capitalize">
+                            {payment.type.replace(/_/g, " ")}
+                          </p>
+                          <p className="text-xs md:text-sm text-muted-foreground">
+                            {formatDate(payment.created_at)} · {formatTime(payment.created_at)}
+                          </p>
+                        </div>
+                        <div
+                          className={`flex-shrink-0 font-semibold text-sm md:text-base ${
+                            isIncoming ? "text-success" : "text-primary"
+                          }`}
+                        >
+                          {isIncoming ? "+" : "-"}
+                          {payment.amount ?? payment.source_amount ?? "–"} {assetLabel}
+                        </div>
+                      </div>
+                    )
+                  })}
+                </div>
+              )}
+            </CardContent>
+          </Card>
         </div>
       </main>
     </div>

--- a/apps/web/app/activity/purchases/page.tsx
+++ b/apps/web/app/activity/purchases/page.tsx
@@ -1,29 +1,31 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { useWallet } from "@/lib/wallet-context"
 import { useI18n } from "@/lib/i18n-context"
+import { useHorizonPayments } from "@/hooks/useHorizonPayments"
 import { Sidebar } from "@/components/sidebar"
 import { DashboardHeader } from "@/components/dashboard-header"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { ArrowLeft, ShoppingCart } from "lucide-react"
+import { ArrowLeft, ShoppingCart, Loader2, AlertCircle } from "lucide-react"
 
-interface Transaction {
-  id: string
-  type: "compra" | "venta"
-  description: string
-  amount: string
-  time: string
-  date: Date
+function formatDate(isoString: string): string {
+  const date = new Date(isoString)
+  return date.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })
+}
+
+function formatTime(isoString: string): string {
+  const date = new Date(isoString)
+  return date.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })
 }
 
 export default function PurchasesPage() {
-  const { isConnected } = useWallet()
+  const { isConnected, address } = useWallet()
   const { t } = useI18n()
   const router = useRouter()
-  const [purchases, setPurchases] = useState<Transaction[]>([])
+  const { payments, isLoading, error, refetch } = useHorizonPayments(address)
 
   useEffect(() => {
     if (!isConnected) {
@@ -31,28 +33,19 @@ export default function PurchasesPage() {
     }
   }, [isConnected, router])
 
-  useEffect(() => {
-    const savedHistory = localStorage.getItem("transactionHistory")
-    if (savedHistory) {
-      const parsed = JSON.parse(savedHistory)
-      const twoMonthsAgo = new Date()
-      twoMonthsAgo.setMonth(twoMonthsAgo.getMonth() - 2)
-
-      const filtered = parsed
-        .map((tx: any) => ({
-          ...tx,
-          date: new Date(tx.time),
-        }))
-        .filter((tx: Transaction) => tx.type === "compra" && tx.date >= twoMonthsAgo)
-        .sort((a: Transaction, b: Transaction) => b.date.getTime() - a.date.getTime())
-
-      setPurchases(filtered)
-    }
-  }, [])
-
   if (!isConnected) {
     return null
   }
+
+  const twoMonthsAgo = new Date()
+  twoMonthsAgo.setMonth(twoMonthsAgo.getMonth() - 2)
+
+  // Incoming payments to this address within the last 2 months
+  const purchases = payments.filter((p) => {
+    const isIncoming = p.to === address
+    const withinRange = new Date(p.created_at) >= twoMonthsAgo
+    return isIncoming && withinRange
+  })
 
   return (
     <div className="min-h-screen bg-background">
@@ -80,27 +73,57 @@ export default function PurchasesPage() {
               </div>
             </CardHeader>
             <CardContent>
-              <div className="space-y-3">
-                {purchases.length > 0 ? (
-                  purchases.map((tx) => (
-                    <div
-                      key={tx.id}
-                      className="flex items-center gap-3 p-4 rounded-lg hover:bg-muted transition-colors border border-border"
-                    >
-                      <div className="flex-shrink-0">
-                        <ShoppingCart className="w-5 h-5 text-success" />
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <p className="font-medium truncate text-sm md:text-base">{tx.description}</p>
-                        <p className="text-xs md:text-sm text-muted-foreground">{tx.time}</p>
-                      </div>
-                      <div className="flex-shrink-0 font-semibold text-sm md:text-base text-success">{tx.amount}</div>
-                    </div>
-                  ))
-                ) : (
-                  <div className="text-center py-8 text-muted-foreground">{t("activity.noPurchases")}</div>
-                )}
-              </div>
+              {isLoading ? (
+                <div className="flex items-center justify-center py-8 text-muted-foreground">
+                  <Loader2 className="w-5 h-5 mr-2 animate-spin" />
+                  {t("activity.loading")}
+                </div>
+              ) : error ? (
+                <div className="flex flex-col items-center gap-3 py-8 text-muted-foreground">
+                  <div className="flex items-center gap-2 text-destructive">
+                    <AlertCircle className="w-5 h-5" />
+                    <span>{t("activity.errorFetching")}</span>
+                  </div>
+                  <Button variant="outline" size="sm" onClick={refetch}>
+                    {t("activity.retry")}
+                  </Button>
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {purchases.length > 0 ? (
+                    purchases.map((payment) => {
+                      const assetLabel =
+                        payment.asset_type === "native"
+                          ? "XLM"
+                          : payment.asset_code ?? payment.asset_type
+
+                      return (
+                        <div
+                          key={payment.id}
+                          className="flex items-center gap-3 p-4 rounded-lg hover:bg-muted transition-colors border border-border"
+                        >
+                          <div className="flex-shrink-0">
+                            <ShoppingCart className="w-5 h-5 text-success" />
+                          </div>
+                          <div className="flex-1 min-w-0">
+                            <p className="font-medium truncate text-sm md:text-base capitalize">
+                              {payment.type.replace(/_/g, " ")}
+                            </p>
+                            <p className="text-xs md:text-sm text-muted-foreground">
+                              {formatDate(payment.created_at)} · {formatTime(payment.created_at)}
+                            </p>
+                          </div>
+                          <div className="flex-shrink-0 font-semibold text-sm md:text-base text-success">
+                            +{payment.amount ?? payment.source_amount ?? "–"} {assetLabel}
+                          </div>
+                        </div>
+                      )
+                    })
+                  ) : (
+                    <div className="text-center py-8 text-muted-foreground">{t("activity.noPurchases")}</div>
+                  )}
+                </div>
+              )}
             </CardContent>
           </Card>
         </div>

--- a/apps/web/hooks/useHorizonPayments.ts
+++ b/apps/web/hooks/useHorizonPayments.ts
@@ -1,0 +1,72 @@
+"use client"
+
+import { useEffect, useState, useCallback } from "react"
+import { STELLAR_CONFIG } from "@/lib/contracts-config"
+
+export interface HorizonPayment {
+  id: string
+  type: string
+  created_at: string
+  transaction_hash: string
+  asset_type: string
+  asset_code?: string
+  asset_issuer?: string
+  from?: string
+  to?: string
+  amount?: string
+  // For account_merge, path_payment, etc.
+  source_amount?: string
+  source_asset_code?: string
+}
+
+interface UseHorizonPaymentsResult {
+  payments: HorizonPayment[]
+  isLoading: boolean
+  error: string | null
+  refetch: () => void
+}
+
+export function useHorizonPayments(address: string | null): UseHorizonPaymentsResult {
+  const [payments, setPayments] = useState<HorizonPayment[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchPayments = useCallback(async () => {
+    if (!address) {
+      setPayments([])
+      return
+    }
+
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const url = `${STELLAR_CONFIG.HORIZON_URL}/accounts/${address}/payments?order=desc&limit=50`
+      const response = await fetch(url)
+
+      if (!response.ok) {
+        if (response.status === 404) {
+          // Account not yet funded on testnet — treat as empty
+          setPayments([])
+          return
+        }
+        throw new Error(`Horizon API error: ${response.status}`)
+      }
+
+      const data = await response.json()
+      const records: HorizonPayment[] = data._embedded?.records ?? []
+      setPayments(records)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch payments")
+      setPayments([])
+    } finally {
+      setIsLoading(false)
+    }
+  }, [address])
+
+  useEffect(() => {
+    fetchPayments()
+  }, [fetchPayments])
+
+  return { payments, isLoading, error, refetch: fetchPayments }
+}

--- a/apps/web/lib/i18n-context.tsx
+++ b/apps/web/lib/i18n-context.tsx
@@ -144,6 +144,11 @@ const translations = {
     "activity.november": "Noviembre",
     "activity.december": "Diciembre",
     "activity.noTransactions": "No hay transacciones registradas",
+    "activity.recentPayments": "Pagos Recientes",
+    "activity.recentPaymentsDescription": "Últimos pagos obtenidos desde la red Stellar (Horizon)",
+    "activity.loading": "Cargando transacciones...",
+    "activity.errorFetching": "No se pudo cargar el historial de pagos",
+    "activity.retry": "Reintentar",
 
     // Consumption Page
     "consumption.description": "Historial de consumo energético desde el inicio",
@@ -283,6 +288,11 @@ const translations = {
     "activity.november": "November",
     "activity.december": "December",
     "activity.noTransactions": "No transactions recorded",
+    "activity.recentPayments": "Recent Payments",
+    "activity.recentPaymentsDescription": "Latest payments fetched from the Stellar network (Horizon)",
+    "activity.loading": "Loading transactions...",
+    "activity.errorFetching": "Could not load payment history",
+    "activity.retry": "Retry",
 
     // Consumption Page
     "consumption.description": "Energy consumption history from the beginning",


### PR DESCRIPTION
## Summary

- Adds `useHorizonPayments` hook that fetches `/accounts/{address}/payments` from `STELLAR_CONFIG.HORIZON_URL` with full loading, error (with retry), and empty state handling
- Updates `activity/page.tsx` to display the 10 most recent Horizon payments with incoming/outgoing indicators directly on the hub page
- Updates `purchases/page.tsx` and `sales/page.tsx` to source data from Horizon instead of localStorage, filtering by direction and last 2 months
- Fixes pre-existing TypeScript errors caused by dependency version bumps (stellar-sdk v14.5, defindex-sdk v0.1.2, react-resizable-panels v4, recharts v3)

## Acceptance Criteria

- [x] Activity view shows a list of recent payments/transactions for the connected account
- [x] Uses Horizon testnet URL from `STELLAR_CONFIG.HORIZON_URL`
- [x] Handles loading, error, and empty states gracefully

## Test plan

- [ ] Connect a Freighter wallet funded on testnet
- [ ] Navigate to `/activity` — verify Recent Payments card shows transactions with date, type, and amount
- [ ] Navigate to `/activity/purchases` — verify only incoming payments appear
- [ ] Navigate to `/activity/sales` — verify only outgoing payments appear
- [ ] Disconnect wallet — verify redirect to `/`
- [ ] Test with an unfunded account — verify empty state (no crash)
- [ ] Test with network error — verify error state + retry button

Closes #14