### PR TITLE
fix: add vercel.json for monorepo deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "buildCommand": "pnpm turbo build --filter=@be-energy/web",
+  "outputDirectory": "apps/web/.next",
+  "installCommand": "pnpm install",
+  "framework": "nextjs"
+}


### PR DESCRIPTION
## Summary
- Adds `vercel.json` at repo root so Vercel finds the Next.js output at `apps/web/.next`
- Fixes deployment error: `.next` directory not found at `/vercel/path0/.next`

## Changes
- `vercel.json`: configures `buildCommand`, `outputDirectory`, `installCommand`, and `framework` for the monorepo structure