### PR TITLE
docs: add Windows Build Tools requirement to prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ Powered by **Turborepo** + **npm workspaces**.
 - **Node.js** v22+ (we use v22 for Corepack compatibility)
 - **npm** v10+ (comes with Node)
 - **Rust** + Cargo (for contracts)
+- **Windows only:** Visual Studio Build Tools with the **"Desktop development with C++"** workload
+   Required to compile native Rust dependencies (e.g., to run `cargo test`).
+   → [Download installer](https://aka.ms/vs/17/release/vs_BuildTools.exe) (~3-6 GB)
+   After installing, restart your terminal before running any Rust commands.
 
 ### Installation
 


### PR DESCRIPTION
## Description

Adds a Windows-specific note to the Prerequisites section in the README.                                                                                                                                                                   
  When running `cargo test` on Windows, native Rust dependencies fail to compile                                                                                                                                                               without Visual Studio Build Tools. This is not obvious and can block contributors
  from running the test suite.

## Related Issue

  N/A

## Type of Change

 - [x] 📝 Documentation update

## Changes Made

- `README.md`: added Windows Build Tools requirement under Prerequisites

## Checklist

- [ ] My code follows the project's style guidelines (run `pnpm format`)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Testing Instructions

1. Open `README.md` and verify the Windows Build Tools note appears under Prerequisites.
