### PR TITLE
fix: Supabase client lazy init for Vercel builds

### DIFF
--- a/apps/web/lib/supabase.ts
+++ b/apps/web/lib/supabase.ts
@@ -1,6 +1,21 @@
-import { createClient } from "@supabase/supabase-js"
+import { createClient, SupabaseClient } from "@supabase/supabase-js"
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
+let _supabase: SupabaseClient
 
-export const supabase = createClient(supabaseUrl, supabaseServiceKey)
+export function getSupabase() {
+  if (!_supabase) {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+    if (!url || !key) {
+      throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY")
+    }
+    _supabase = createClient(url, key)
+  }
+  return _supabase
+}
+
+export const supabase = new Proxy({} as SupabaseClient, {
+  get(_, prop) {
+    return (getSupabase() as Record<string | symbol, unknown>)[prop]
+  },
+})


### PR DESCRIPTION
## Summary
- Fix Vercel deploy crash: `Error: supabaseUrl is required` during build
- Supabase client was instantiated at module load time, which fails when env vars aren't available during static page generation
- Changed to lazy initialization via Proxy — client is only created on first actual use (runtime), not at import time (build)

## Test plan
- [x] Build passes **without** Supabase env vars set
- [x] 13 API tests still passing
- [x] Verified locally with `NEXT_PUBLIC_SUPABASE_URL="" pnpm turbo build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)