### PR TITLE
fix: remove hardcoded tx hash from success modal

### DIFF
--- a/apps/web/app/marketplace/page.tsx
+++ b/apps/web/app/marketplace/page.tsx
@@ -43,7 +43,7 @@ export default function MarketplacePage() {
   const [selectedOffer, setSelectedOffer] = useState<Offer | null>(null)
   const [newOfferAmount, setNewOfferAmount] = useState("")
   const [newOfferPrice, setNewOfferPrice] = useState("")
-  const [successData, setSuccessData] = useState<{ type: "compra" | "venta"; amount: number; xlmAmount: number }>({
+  const [successData, setSuccessData] = useState<{ type: "compra" | "venta"; amount: number; xlmAmount: number; txHash?: string }>({
     type: "compra",
     amount: 0,
     xlmAmount: 0,
@@ -380,6 +380,7 @@ export default function MarketplacePage() {
         type={successData.type}
         amount={successData.amount}
         xlmAmount={successData.xlmAmount}
+        txHash={successData.txHash}
       />
     </div>
   )

--- a/apps/web/components/success-modal.tsx
+++ b/apps/web/components/success-modal.tsx
@@ -22,7 +22,7 @@ export function SuccessModal({
   type,
   amount,
   xlmAmount,
-  txHash = "ABC123DEF456GHI789JKL012MNO345PQR678",
+  txHash = "",
 }: SuccessModalProps) {
   const router = useRouter()
   const { t } = useI18n()
@@ -48,7 +48,7 @@ export function SuccessModal({
     router.push("/dashboard")
   }
 
-  const shortHash = `${txHash.slice(0, 8)}...${txHash.slice(-8)}`
+  const shortHash = txHash ? `${txHash.slice(0, 8)}...${txHash.slice(-8)}` : null
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -105,25 +105,26 @@ export function SuccessModal({
           </div>
 
           {/* Transaction Hash */}
-          <div className="w-full space-y-2">
-            <p className="text-sm text-muted-foreground">{t("success.txHash")}</p>
-            <div className="flex items-center gap-2 bg-muted rounded-lg p-3">
-              <code className="flex-1 text-sm font-mono truncate">{shortHash}</code>
-              <Button size="sm" variant="ghost" onClick={handleCopy} className="flex-shrink-0">
-                {copied ? <CheckCircle className="w-4 h-4 text-success" /> : <Copy className="w-4 h-4" />}
-              </Button>
+          {txHash && (
+            <div className="w-full space-y-2">
+              <p className="text-sm text-muted-foreground">{t("success.txHash")}</p>
+              <div className="flex items-center gap-2 bg-muted rounded-lg p-3">
+                <code className="flex-1 text-sm font-mono truncate">{shortHash}</code>
+                <Button size="sm" variant="ghost" onClick={handleCopy} className="flex-shrink-0">
+                  {copied ? <CheckCircle className="w-4 h-4 text-success" /> : <Copy className="w-4 h-4" />}
+                </Button>
+              </div>
+              <a
+                href={`https://stellar.expert/explorer/testnet/tx/${txHash}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-primary hover:underline flex items-center gap-1 justify-center"
+              >
+                {t("success.viewOnStellarExpert")}
+                <ExternalLink className="w-3 h-3" />
+              </a>
             </div>
-            <a
-              href={`https://stellar.expert/explorer/testnet/tx/${txHash}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-sm text-primary hover:underline flex items-center gap-1 justify-center"
-            >
-              {t("success.viewOnStellarExpert")}
-              <ExternalLink className="w-3 h-3" />
-            </a>
-          </div>
-
+          )}
           {/* Action Button */}
           <Button onClick={handleClose} className="w-full gradient-primary text-white font-semibold" size="lg">
             {t("success.close")}


### PR DESCRIPTION
… #51

## Description

Removes the hardcoded fake transaction hash (`ABC123DEF456GHI789JKL012MNO345PQR678`) from the success modal. The hash block now only renders when a real hash is provided.

## Related Issue

Closes #51

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] ♻️ Code refactoring
- [ ] 🧪 Test addition/update

## Changes Made

- `success-modal.tsx`: default txHash changed from fake string to empty string. Transaction hash block wrapped in `{txHash && (...)}` so it only renders when a real hash exists.
- `marketplace/page.tsx`: added `txHash?` to successData state type and passed it to SuccessModal component.

## Checklist

- [x] My code follows the project's style guidelines (run `pnpm format`)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Testing Instructions

1. Checkout this branch: `git checkout fix/hardcoded-tx-hash-success-modal`
2. Install dependencies: `pnpm install`
3. Start dev server: `pnpm dev`
4. Navigate to `/marketplace`
5. Complete a buy or sell transaction
6. Verify success modal appears without fake hash or broken Stellar Expert link


## Screenshots (if applicable)

Before: Modal showed hardcoded hash "ABC123DE...45PQR678" and broken Stellar Expert link
After: Modal shows transaction details only, no hash block (hash will appear when real on-chain transactions are connected)


## Additional Context

<!-- Any other information that reviewers should know -->

---

## For Bounty Issues

- [ ] I have linked the bounty issue this PR resolves
- [ ] All acceptance criteria from the issue are met
- [ ] I have tested on testnet with Freighter wallet (if applicable)
- [ ] I have provided my Stellar address for bounty payout: `G...`

