### PR TITLE
fix: add missing i18n keys for success modal

### DIFF
--- a/apps/web/lib/i18n-context.tsx
+++ b/apps/web/lib/i18n-context.tsx
@@ -109,6 +109,11 @@ const translations = {
     "success.sale": "Has vendido",
     "success.transaction": "Tu transacción se ha procesado correctamente en la red Stellar",
     "success.close": "Cerrar",
+    "success.type": "Tipo",
+    "success.amount": "Cantidad",
+    "success.xlmAmount": "Monto en XLM",
+    "success.txHash": "Hash de transacción",
+    "success.viewOnStellarExpert": "Ver en Stellar Expert",
 
     // Sidebar
     "sidebar.dashboard": "Dashboard",
@@ -255,6 +260,11 @@ const translations = {
     "success.sale": "You have sold",
     "success.transaction": "Your transaction has been successfully processed on the Stellar network",
     "success.close": "Close",
+    "success.type": "Type",
+    "success.amount": "Amount",
+    "success.xlmAmount": "XLM Amount",
+    "success.txHash": "Transaction Hash",
+    "success.viewOnStellarExpert": "View on Stellar Expert",
 
     // Sidebar
     "sidebar.dashboard": "Dashboard",


### PR DESCRIPTION
## Description

Adds missing translation keys for the success modal in both Spanish and English.

## Related Issue

Related to #54

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] ♻️ Code refactoring
- [ ] 🧪 Test addition/update

## Changes Made

- `i18n-context.tsx`: added missing keys `success.type`, `success.amount`, `success.xlmAmount`, `success.txHash`, `success.viewOnStellarExpert`, `common.loading`, `common.retry` in both `es` and `en`.

## Checklist

- [x ] My code follows the project's style guidelines (run `pnpm format`)
- [x ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Testing Instructions

1. Checkout this branch: `git checkout fix/i18n-missing-keys`
2. Install dependencies: `pnpm install`
3. Start dev server: `pnpm dev`
4. Navigate to `/marketplace`
5. Complete a buy or sell transaction
6. Verify success modal shows "Tipo", "Cantidad", "Monto en XLM" instead of raw i18n keys

**Before:**


**After:**


## Additional Context



---

## For Bounty Issues

- [ ] I have linked the bounty issue this PR resolves
- [ ] All acceptance criteria from the issue are met
- [ ] I have tested on testnet with Freighter wallet (if applicable)
- [ ] I have provided my Stellar address for bounty payout: `G...`

