### PR TITLE
docs: limpiar testing, eliminar flujo legacy

### DIFF
--- a/docs/8-TESTING.md
+++ b/docs/8-TESTING.md
@@ -28,22 +28,6 @@ cd apps/web && pnpm test
 
 ---
 
-## Simulación Testnet (legacy)
-
-> Nota: La simulación original (v0.2.0) usaba un flujo P2P con token HDROP, marketplace y offers. Ese flujo fue reemplazado por el modelo de certificación actual. El script `scripts/simulate-testnet.ts` queda como referencia histórica.
-
-### Contratos deployados (Testnet, v0.2.0)
-
-| Contrato | Address | Explorer |
-|----------|---------|----------|
-| ENERGY_TOKEN (HDROP) | `CAUH3NUZGCNRHHVJK5S3FLXIS244GCNPC2LDZDU2SVOK66G3IGAGBBL2` | [Stellar Expert](https://stellar.expert/explorer/testnet/contract/CAUH3NUZGCNRHHVJK5S3FLXIS244GCNPC2LDZDU2SVOK66G3IGAGBBL2) |
-| ENERGY_DISTRIBUTION | `CDXWZSWTM6DGYTDME3BEDE6U7JBHMG4YM7ZW237UZS2XTUWFVEEMIROR` | [Stellar Expert](https://stellar.expert/explorer/testnet/contract/CDXWZSWTM6DGYTDME3BEDE6U7JBHMG4YM7ZW237UZS2XTUWFVEEMIROR) |
-| COMMUNITY_GOVERNANCE | `CCH2EXXNSDW2BAKBIPFAG6CCZS6LV4VJFUP2CZZCW5LEY4JOAXBJD6YI` | [Stellar Expert](https://stellar.expert/explorer/testnet/contract/CCH2EXXNSDW2BAKBIPFAG6CCZS6LV4VJFUP2CZZCW5LEY4JOAXBJD6YI) |
-
-Estos contratos se redesplegarán con los cambios de v0.3.0 (nombre parametrizable, cooperative_id, Pausable + Upgradeable).
-
----
-
 ## Integration Test — Circuito completo en Stellar Testnet
 
 Test end-to-end que ejecuta el circuito real del producto contra Stellar Testnet.
@@ -71,7 +55,7 @@ npx tsx scripts/integration-test.ts
 | **Mint** (38.5 kWh) | `6ec071c2...` | [Stellar Expert](https://stellar.expert/explorer/testnet/tx/6ec071c257f628ba8c544539c8401b47c1cd10bd54a8b4b8bb168fe4c5522070) |
 | **Burn** (38.5 kWh) | `afd646aa...` | [Stellar Expert](https://stellar.expert/explorer/testnet/tx/afd646aab80f055d5fec4176772ae67825b63865e42c8aca5d290c5a04ae9218) |
 
-Contrato utilizado: `CCYOVOFDJ5BVBSI6HADLWETTUF3BU423MEAWBSBWV2X5UVNKSJMRPBA6` ([Explorer](https://stellar.expert/explorer/testnet/contract/CCYOVOFDJ5BVBSI6HADLWETTUF3BU423MEAWBSBWV2X5UVNKSJMRPBA6))
+Contrato: Energy Token [`CCYOVOFDJ5...`](https://stellar.expert/explorer/testnet/contract/CCYOVOFDJ5BVBSI6HADLWETTUF3BU423MEAWBSBWV2X5UVNKSJMRPBA6) (ver [5-CONTRACTS.md](5-CONTRACTS.md) para todos los contratos deployados)
 
 ### Modelo custodial
 
@@ -105,46 +89,6 @@ COOPERATIVE_ID=<uuid> pnpm meter:mock
 
 ---
 
-## Flujo de verificación actual (v0.3.0)
-
-```
-1. Registrar cooperativa
-   POST /api/cooperatives
-   { name, technology, admin_stellar_address }
-
-2. Registrar miembros
-   POST /api/members
-   { stellar_address, cooperative_id }
-
-3. Registrar medidores
-   POST /api/meters
-   { cooperative_id, member_stellar_address, device_type, technology, capacity_kw }
-
-4. Cargar lecturas (medidor inteligente envía vía API)
-   POST /api/readings                → lectura individual
-   POST /api/meters/readings          → ingesta bulk
-
-5. Crear proto-certificado
-   POST /api/certificates
-   { cooperative_id, generation_period_start, generation_period_end, total_kwh, technology }
-
-6. Mintear on-chain
-   POST /api/mint
-   { certificate_id }
-   → Soroban tx: mint_energy() → status: available
-
-7. Retirar certificado (comprador externo)
-   POST /api/certificates/retire
-   { certificate_id, buyer_address, buyer_purpose }
-   → Soroban tx: burn_energy() → status: retired
-
-8. Ver estadísticas
-   GET /api/certificates/stats
-   → total_kwh_certified, total_kwh_retired, co2_avoided_kg
-```
-
----
-
 ## Cómo correr los tests
 
 ### Unit tests
@@ -158,6 +102,14 @@ cd apps/web && pnpm test
 ```bash
 cd apps/contracts && cargo test
 ```
+
+### Integration test (Stellar Testnet)
+
+```bash
+npx tsx scripts/integration-test.ts
+```
+
+Requiere `apps/web/.env.local` con las variables de Stellar y Supabase configuradas.
 
 ### Setup DB (primera vez o migración)
 


### PR DESCRIPTION
## Summary
- Eliminar sección legacy (v0.2.0 HDROP/marketplace) de 8-TESTING.md
- Eliminar flujo de verificación redundante (ya cubierto por integration test)
- Agregar comando de integration test a sección "Cómo correr los tests"
- Referenciar contratos actuales (5-CONTRACTS.md)