### PR TITLE
feat: Stellar Expert link should switch between testnet and mainnet automatically

### DIFF
--- a/FUNDING.json
+++ b/FUNDING.json
@@ -1,0 +1,7 @@
+{
+  "drips": {
+    "optimism": {
+      "ownedBy": "0x7d012643D8E72994895F826A22E72ca972D576fd"
+    }
+  }
+}

--- a/apps/web/__tests__/lib/utils.test.ts
+++ b/apps/web/__tests__/lib/utils.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import * as fc from "fast-check"
+import { getStellarExpertUrl } from "@/lib/utils"
+
+describe("getStellarExpertUrl", () => {
+  const originalEnv = process.env.NEXT_PUBLIC_STELLAR_NETWORK
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.NEXT_PUBLIC_STELLAR_NETWORK
+    } else {
+      process.env.NEXT_PUBLIC_STELLAR_NETWORK = originalEnv
+    }
+  })
+
+  it("returns testnet URL for a known hash when NEXT_PUBLIC_STELLAR_NETWORK is TESTNET", () => {
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK = "TESTNET"
+    const result = getStellarExpertUrl("abc123")
+    expect(result).toBe("https://stellar.expert/explorer/testnet/tx/abc123")
+  })
+
+  it("returns mainnet URL for a known hash when NEXT_PUBLIC_STELLAR_NETWORK is MAINNET", () => {
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK = "MAINNET"
+    const result = getStellarExpertUrl("abc123")
+    expect(result).toBe("https://stellar.expert/explorer/public/tx/abc123")
+  })
+
+  it("defaults to testnet URL when NEXT_PUBLIC_STELLAR_NETWORK is not set", () => {
+    delete process.env.NEXT_PUBLIC_STELLAR_NETWORK
+    const result = getStellarExpertUrl("abc123")
+    expect(result).toBe("https://stellar.expert/explorer/testnet/tx/abc123")
+  })
+
+  it("does not crash and URL ends with empty string when hash is empty", () => {
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK = "TESTNET"
+    const result = getStellarExpertUrl("")
+    expect(result).toBe("https://stellar.expert/explorer/testnet/tx/")
+    expect(result.endsWith("")).toBe(true)
+  })
+})
+
+describe("getStellarExpertUrl — property-based tests", () => {
+  const TESTNET_PREFIX = "https://stellar.expert/explorer/testnet/tx/"
+  const MAINNET_PREFIX = "https://stellar.expert/explorer/public/tx/"
+
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_STELLAR_NETWORK
+  })
+
+  it(
+    "Feature: stellar-expert-url, Property 1: Testnet URL structure",
+    () => {
+      fc.assert(
+        fc.property(fc.string(), (hash) => {
+          process.env.NEXT_PUBLIC_STELLAR_NETWORK = "TESTNET"
+          const url = getStellarExpertUrl(hash)
+          expect(url.startsWith(TESTNET_PREFIX)).toBe(true)
+          expect(url.endsWith(hash)).toBe(true)
+        })
+      )
+    }
+  )
+
+  it(
+    "Feature: stellar-expert-url, Property 2: Mainnet URL structure",
+    () => {
+      fc.assert(
+        fc.property(fc.string(), (hash) => {
+          process.env.NEXT_PUBLIC_STELLAR_NETWORK = "MAINNET"
+          const url = getStellarExpertUrl(hash)
+          expect(url.startsWith(MAINNET_PREFIX)).toBe(true)
+          expect(url.endsWith(hash)).toBe(true)
+        })
+      )
+    }
+  )
+
+  it(
+    "Feature: stellar-expert-url, Property 3: Unknown network defaults to testnet",
+    () => {
+      fc.assert(
+        fc.property(
+          fc.string(),
+          fc.oneof(
+            fc.constant(undefined),
+            fc.string().filter((s) => s !== "TESTNET" && s !== "MAINNET")
+          ),
+          (hash, envValue) => {
+            if (envValue === undefined) {
+              delete process.env.NEXT_PUBLIC_STELLAR_NETWORK
+            } else {
+              process.env.NEXT_PUBLIC_STELLAR_NETWORK = envValue
+            }
+            const url = getStellarExpertUrl(hash)
+            expect(url.startsWith(TESTNET_PREFIX)).toBe(true)
+          }
+        )
+      )
+    }
+  )
+
+  it(
+    "Feature: stellar-expert-url, Property 4: Hash is preserved verbatim",
+    () => {
+      fc.assert(
+        fc.property(
+          fc.string(),
+          fc.constantFrom("TESTNET", "MAINNET", "OTHER", undefined as unknown as string),
+          (hash, envValue) => {
+            if (envValue === undefined) {
+              delete process.env.NEXT_PUBLIC_STELLAR_NETWORK
+            } else {
+              process.env.NEXT_PUBLIC_STELLAR_NETWORK = envValue
+            }
+            const url = getStellarExpertUrl(hash)
+            expect(url.endsWith(hash)).toBe(true)
+          }
+        )
+      )
+    }
+  )
+})

--- a/apps/web/app/certificates/page.tsx
+++ b/apps/web/app/certificates/page.tsx
@@ -16,6 +16,7 @@ import { InfoTooltip } from "@/components/shared/info-tooltip"
 import { Spinner } from "@/components/ui/spinner"
 import { useAuth } from "@/lib/auth-context"
 import { RetireCertificateModal } from "@/components/modals/retire-certificate-modal"
+import { getStellarExpertUrl } from "@/lib/utils"
 
 function formatDate(isoString: string): string {
   return new Date(isoString).toLocaleDateString("es-ES", { year: "numeric", month: "short", day: "numeric" })
@@ -36,7 +37,6 @@ function StatusBadge({ status, t }: { status: string; t: (key: string) => string
 
 function CertificateCard({ cert, t, onRetire }: { cert: Certificate; t: (key: string) => string; onRetire?: (cert: Certificate) => void }) {
   const [expanded, setExpanded] = useState(false)
-  const stellarExpertBase = "https://stellar.expert/explorer/testnet/tx/"
 
   return (
     <Card className="border border-border">
@@ -66,7 +66,7 @@ function CertificateCard({ cert, t, onRetire }: { cert: Certificate; t: (key: st
             )}
             {cert.mint_tx_hash && (
               <a
-                href={`${stellarExpertBase}${cert.mint_tx_hash}`}
+                href={getStellarExpertUrl(cert.mint_tx_hash)}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-web3-purple hover:text-web3-purple/80 transition-colors"

--- a/apps/web/app/dashboard/admin/page.tsx
+++ b/apps/web/app/dashboard/admin/page.tsx
@@ -13,6 +13,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Spinner } from "@/components/ui/spinner"
 import { Building2, Users, Zap, Award, Shield, ShieldAlert, ArrowRight, ExternalLink } from "lucide-react"
 import { InfoTooltip } from "@/components/shared/info-tooltip"
+import { getStellarExpertUrl } from "@/lib/utils"
 
 export default function SuperAdminPage() {
   const { isConnected, isPending: walletPending } = useWallet()
@@ -31,7 +32,6 @@ export default function SuperAdminPage() {
   const isPageLoading = authLoading || walletPending || loading
 
   const truncateAddress = (addr: string) => `${addr.slice(0, 6)}...${addr.slice(-4)}`
-  const stellarExpertBase = "https://stellar.expert/explorer/testnet"
 
   return (
     <div className="min-h-screen bg-background">
@@ -214,7 +214,7 @@ export default function SuperAdminPage() {
                             </div>
                             {mint.mint_tx_hash && (
                               <a
-                                href={`${stellarExpertBase}/tx/${mint.mint_tx_hash}`}
+                                href={getStellarExpertUrl(mint.mint_tx_hash)}
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 className="text-primary hover:text-primary/80"

--- a/apps/web/components/modals/retire-certificate-modal.tsx
+++ b/apps/web/components/modals/retire-certificate-modal.tsx
@@ -6,6 +6,7 @@ import { useWallet } from "@/lib/wallet-context"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { X, Flame, AlertCircle, CheckCircle2, ExternalLink } from "lucide-react"
+import { getStellarExpertUrl } from "@/lib/utils"
 
 interface Certificate {
   id: string
@@ -100,7 +101,7 @@ export function RetireCertificateModal({ isOpen, onClose, certificate, onSuccess
             <CheckCircle2 className="w-12 h-12 text-energy-green mx-auto mb-3" />
             <p className="font-semibold text-foreground mb-2">{t("retire.success")}</p>
             <a
-              href={`https://stellar.expert/explorer/testnet/tx/${txHash}`}
+              href={getStellarExpertUrl(txHash)}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-1 text-sm text-primary hover:underline"

--- a/apps/web/components/success-modal.tsx
+++ b/apps/web/components/success-modal.tsx
@@ -6,6 +6,7 @@ import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { CheckCircle, Copy, ExternalLink, Leaf } from "lucide-react"
 import { useRouter } from "next/navigation"
+import { getStellarExpertUrl } from "@/lib/utils"
 
 interface SuccessModalProps {
   open: boolean
@@ -128,7 +129,7 @@ export function SuccessModal({
                 </Button>
               </div>
               <a
-                href={`https://stellar.expert/explorer/testnet/tx/${txHash}`}
+                href={getStellarExpertUrl(txHash)}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-sm text-primary hover:underline flex items-center gap-1 justify-center"

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -5,6 +5,22 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+/**
+ * Returns a fully-qualified Stellar Expert transaction URL for the given
+ * transaction hash, targeting the network configured via
+ * NEXT_PUBLIC_STELLAR_NETWORK.
+ *
+ * Defaults to testnet when the variable is absent or unrecognised.
+ */
+export function getStellarExpertUrl(txHash: string): string {
+  const network = process.env.NEXT_PUBLIC_STELLAR_NETWORK
+  const explorer =
+    network === "MAINNET"
+      ? "https://stellar.expert/explorer/public/tx/"
+      : "https://stellar.expert/explorer/testnet/tx/"
+  return `${explorer}${txHash}`
+}
+
 export function generateIdenticon(address: string): string {
   let hash = 0
   for (let i = 0; i < address.length; i++) {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -78,6 +78,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/three": "^0.183.1",
+    "fast-check": "^4.6.0",
     "postcss": "^8.5",
     "tailwindcss": "^4.1.9",
     "typescript": "^5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,7 +143,7 @@ importers:
         version: 2.98.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@vercel/analytics':
         specifier: latest
-        version: 1.6.1(next@16.0.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+        version: 2.0.1(next@16.0.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -235,6 +235,9 @@ importers:
       '@types/three':
         specifier: ^0.183.1
         version: 0.183.1
+      fast-check:
+        specifier: ^4.6.0
+        version: 4.6.0
       postcss:
         specifier: ^8.5
         version: 8.5.6
@@ -2440,12 +2443,13 @@ packages:
     peerDependencies:
       react: '>= 16.8.0'
 
-  '@vercel/analytics@1.6.1':
-    resolution: {integrity: sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==}
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
     peerDependencies:
       '@remix-run/react': ^2
       '@sveltejs/kit': ^1 || ^2
       next: '>= 13'
+      nuxt: '>= 3'
       react: ^18 || ^19 || ^19.0.0-rc
       svelte: '>= 4'
       vue: ^3
@@ -2456,6 +2460,8 @@ packages:
       '@sveltejs/kit':
         optional: true
       next:
+        optional: true
+      nuxt:
         optional: true
       react:
         optional: true
@@ -3077,6 +3083,10 @@ packages:
   eyes@0.1.8:
     resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
     engines: {node: '> 0.1.90'}
+
+  fast-check@4.6.0:
+    resolution: {integrity: sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==}
+    engines: {node: '>=12.17.0'}
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
@@ -3720,6 +3730,9 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  pure-rand@8.3.0:
+    resolution: {integrity: sha512-1ws1Ab8fnsf4bvpL+SujgBnr3KFs5abgCLVzavBp+f2n8Ld5YTOZlkv/ccYPhu3X9s+MEeqPRMqKlJz/kWDK8A==}
 
   pushdata-bitcoin@1.0.1:
     resolution: {integrity: sha512-hw7rcYTJRAl4olM8Owe8x0fBuJJ+WGbMhQuLWOXEMN3PxPCKQHRkhfL+XG0+iXUmSHjkMmb3Ba55Mt21cZc9kQ==}
@@ -7383,7 +7396,7 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 19.2.0
 
-  '@vercel/analytics@1.6.1(next@16.0.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
+  '@vercel/analytics@2.0.1(next@16.0.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
     optionalDependencies:
       next: 16.0.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
@@ -8239,6 +8252,10 @@ snapshots:
 
   eyes@0.1.8: {}
 
+  fast-check@4.6.0:
+    dependencies:
+      pure-rand: 8.3.0
+
   fast-json-stable-stringify@2.1.0: {}
 
   fast-redact@3.5.0: {}
@@ -8878,6 +8895,8 @@ snapshots:
   proxy-compare@2.5.1: {}
 
   proxy-from-env@1.1.0: {}
+
+  pure-rand@8.3.0: {}
 
   pushdata-bitcoin@1.0.1:
     dependencies:


### PR DESCRIPTION

- Add getStellarExpertUrl(txHash) to lib/utils.ts, reads NEXT_PUBLIC_STELLAR_NETWORK
- Replace hardcoded stellar.expert testnet URLs in success-modal.tsx, retire-certificate-modal.tsx, certificates/page.tsx, dashboard/admin/page.tsx
- Add unit tests and property-based tests (fast-check) in __tests__/lib/utils.test.ts

## Description

<!-- Provide a clear description of the changes in this PR -->

## Related Issue

Closes #137


## Checklist

- [ ] My code follows the project's style guidelines (run `pnpm format`)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
