### PR TITLE
Block certificate creation if readings are not verified

### DIFF
--- a/apps/web/__tests__/api/certificates.test.ts
+++ b/apps/web/__tests__/api/certificates.test.ts
@@ -4,22 +4,31 @@ import { NextRequest } from "next/server"
 const ADDR = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 const COOP_ID = "00000000-0000-0000-0000-000000000001"
 
-const { mockSingle, mockOrder, mockFrom } = vi.hoisted(() => {
+const { mockSingle, mockOrder, mockFrom, mockLimit } = vi.hoisted(() => {
   const mockSingle = vi.fn()
+  const mockLimit = vi.fn(() => ({ data: [], error: null }))
   const mockOrder = vi.fn(() => ({ data: [], error: null }))
   const mockEq: ReturnType<typeof vi.fn> = vi.fn(() => ({
     order: mockOrder,
     eq: mockEq,
-    gte: vi.fn(() => ({ lte: vi.fn(() => ({ data: [], error: null })), order: mockOrder, eq: mockEq })),
+    gte: vi.fn(() => ({
+      lte: vi.fn(() => ({
+        limit: mockLimit,
+        data: [],
+        error: null
+      })),
+      order: mockOrder,
+      eq: mockEq
+    })),
     lte: vi.fn(() => ({ data: [], error: null })),
   }))
-  const mockSelect = vi.fn(() => ({ single: mockSingle }))
+  const mockSelect = vi.fn(() => ({ single: mockSingle, eq: mockEq }))
   const mockInsert = vi.fn(() => ({ select: mockSelect }))
   const mockFrom = vi.fn(() => ({
-    select: vi.fn(() => ({ order: mockOrder, eq: mockEq })),
+    select: mockSelect,
     insert: mockInsert,
   }))
-  return { mockSingle, mockOrder, mockFrom }
+  return { mockSingle, mockOrder, mockFrom, mockLimit }
 })
 
 vi.mock("@/lib/supabase", () => ({
@@ -77,7 +86,24 @@ describe("POST /api/certificates", () => {
     expect(json.error).toMatch(/Validation failed/)
   })
 
-  it("crea certificado válido → 201", async () => {
+  it("rechaza si no hay lecturas verificadas → 400", async () => {
+    mockLimit.mockResolvedValueOnce({ data: [], error: null })
+
+    const res = await POST(
+      makePost({
+        cooperative_id: COOP_ID,
+        generation_period_start: "2025-01-01",
+        generation_period_end: "2025-01-31",
+        total_kwh: 150,
+        technology: "solar",
+      })
+    )
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.error).toMatch(/No verified readings for this period/)
+  })
+
+  it("crea certificado válido con lecturas verificadas → 201", async () => {
     const fakeCert = {
       id: "cert-1",
       cooperative_id: COOP_ID,
@@ -85,6 +111,7 @@ describe("POST /api/certificates", () => {
       technology: "solar",
       status: "pending",
     }
+    mockLimit.mockResolvedValueOnce({ data: [{ id: "reading-1" }], error: null })
     mockSingle.mockResolvedValueOnce({ data: fakeCert, error: null })
 
     const res = await POST(

--- a/apps/web/__tests__/api/readings.test.ts
+++ b/apps/web/__tests__/api/readings.test.ts
@@ -5,16 +5,18 @@ const ADDR = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 const COOP_ID = "00000000-0000-0000-0000-000000000001"
 const METER_ID = "00000000-0000-0000-0000-000000000004"
 
-const { mockSingle, mockEq, mockFrom } = vi.hoisted(() => {
+const { mockSingle, mockEq, mockFrom, mockUpdate } = vi.hoisted(() => {
   const mockSingle = vi.fn()
-  const mockEq: ReturnType<typeof vi.fn> = vi.fn(() => ({ single: mockSingle, eq: mockEq }))
-  const mockSelect = vi.fn(() => ({ single: mockSingle }))
+  const mockSelect = vi.fn(() => ({ single: mockSingle, eq: mockEq }))
+  const mockEq: ReturnType<typeof vi.fn> = vi.fn(() => ({ single: mockSingle, eq: mockEq, select: mockSelect }))
   const mockInsert = vi.fn(() => ({ select: mockSelect }))
+  const mockUpdate = vi.fn(() => ({ eq: mockEq, select: mockSelect }))
   const mockFrom = vi.fn(() => ({
     select: vi.fn(() => ({ eq: mockEq })),
     insert: mockInsert,
+    update: mockUpdate,
   }))
-  return { mockSingle, mockEq, mockFrom }
+  return { mockSingle, mockEq, mockFrom, mockUpdate }
 })
 
 vi.mock("@/lib/supabase", () => ({
@@ -27,10 +29,15 @@ vi.mock("@/lib/auth/middleware", () => ({
     cooperative_ids: [COOP_ID],
     admin_cooperative_ids: [COOP_ID],
   })),
+  requireAdmin: vi.fn(async () => ({
+    sub: ADDR,
+    cooperative_ids: [COOP_ID],
+    admin_cooperative_ids: [COOP_ID],
+  })),
   isSession: vi.fn(() => true),
 }))
 
-import { POST } from "@/app/api/readings/route"
+import { POST, PATCH } from "@/app/api/readings/route"
 
 function makeRequest(body: Record<string, unknown>) {
   return new NextRequest("http://localhost/api/readings", {
@@ -103,5 +110,70 @@ describe("POST /api/readings", () => {
     const json = await res.json()
     expect(json.status).toBe("pending")
     expect(json.id).toBe("reading-1")
+  })
+})
+
+function makePatchRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/readings", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  })
+}
+
+describe("PATCH /api/readings", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  const READING_ID = "00000000-0000-0000-0000-000000000010"
+
+  it("rechaza sin reading_id → 400", async () => {
+    const res = await PATCH(makePatchRequest({ status: "verified" }))
+    expect(res.status).toBe(400)
+  })
+
+  it("rechaza con status inválido → 400", async () => {
+    const res = await PATCH(makePatchRequest({ reading_id: READING_ID, status: "invalid" }))
+    expect(res.status).toBe(400)
+  })
+
+  it("rechaza si reading no existe → 404", async () => {
+    mockSingle.mockResolvedValueOnce({ data: null, error: null })
+
+    const res = await PATCH(makePatchRequest({ reading_id: READING_ID, status: "verified" }))
+    expect(res.status).toBe(404)
+    const json = await res.json()
+    expect(json.error).toMatch(/Reading not found/)
+  })
+
+  it("actualiza status a verified → 200", async () => {
+    const updatedReading = {
+      id: READING_ID,
+      cooperative_id: COOP_ID,
+      status: "verified",
+      kwh_generated: 5,
+    }
+    mockSingle.mockResolvedValueOnce({ data: { cooperative_id: COOP_ID }, error: null })
+    mockSingle.mockResolvedValueOnce({ data: updatedReading, error: null })
+
+    const res = await PATCH(makePatchRequest({ reading_id: READING_ID, status: "verified" }))
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.status).toBe("verified")
+    expect(json.id).toBe(READING_ID)
+  })
+
+  it("actualiza status a rejected → 200", async () => {
+    const updatedReading = {
+      id: READING_ID,
+      cooperative_id: COOP_ID,
+      status: "rejected",
+      kwh_generated: 5,
+    }
+    mockSingle.mockResolvedValueOnce({ data: { cooperative_id: COOP_ID }, error: null })
+    mockSingle.mockResolvedValueOnce({ data: updatedReading, error: null })
+
+    const res = await PATCH(makePatchRequest({ reading_id: READING_ID, status: "rejected" }))
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.status).toBe("rejected")
   })
 })

--- a/apps/web/app/api/certificates/route.ts
+++ b/apps/web/app/api/certificates/route.ts
@@ -42,6 +42,25 @@ export async function POST(req: NextRequest) {
     const session = await requireAdmin(v.data.cooperative_id)
     if (!isSession(session)) return session
 
+    // Check for verified readings in the certificate period
+    const { data: verifiedReadings, error: readingsError } = await supabase
+      .from("readings")
+      .select("id")
+      .eq("cooperative_id", v.data.cooperative_id)
+      .eq("status", "verified")
+      .gte("reading_date", v.data.generation_period_start)
+      .lte("reading_date", v.data.generation_period_end)
+      .limit(1)
+
+    if (readingsError) return safeDbError(readingsError)
+
+    if (!verifiedReadings || verifiedReadings.length === 0) {
+      return NextResponse.json(
+        { error: "No verified readings for this period" },
+        { status: 400 }
+      )
+    }
+
     const { data, error } = await supabase
       .from("certificates")
       .insert({

--- a/apps/web/app/api/readings/route.ts
+++ b/apps/web/app/api/readings/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server"
 import { supabase } from "@/lib/supabase"
-import { requireAuth, isSession } from "@/lib/auth/middleware"
+import { requireAuth, requireAdmin, isSession } from "@/lib/auth/middleware"
 import { validateBody } from "@/lib/validation/validate"
-import { createReadingSchema } from "@/lib/validation/schemas"
+import { createReadingSchema, updateReadingSchema } from "@/lib/validation/schemas"
 import { safeDbError, safeCatchError } from "@/lib/errors/safe-error"
 
 // GET: authenticated — scoped to caller's cooperatives
@@ -169,6 +169,44 @@ export async function POST(req: NextRequest) {
     if (insertError) return safeDbError(insertError)
 
     return NextResponse.json(reading, { status: 201 })
+  } catch (err) {
+    return safeCatchError(err)
+  }
+}
+
+// PATCH: admin — update reading status (verify/reject)
+export async function PATCH(req: NextRequest) {
+  try {
+    const body = await req.json()
+    const v = validateBody(updateReadingSchema, body)
+    if (!v.success) return v.response
+
+    // Get the reading to check cooperative_id
+    const { data: reading } = await supabase
+      .from("readings")
+      .select("cooperative_id")
+      .eq("id", v.data.reading_id)
+      .single()
+
+    if (!reading) {
+      return NextResponse.json({ error: "Reading not found" }, { status: 404 })
+    }
+
+    // Require admin of the cooperative
+    const session = await requireAdmin(reading.cooperative_id)
+    if (!isSession(session)) return session
+
+    // Update reading status
+    const { data: updated, error } = await supabase
+      .from("readings")
+      .update({ status: v.data.status })
+      .eq("id", v.data.reading_id)
+      .select()
+      .single()
+
+    if (error) return safeDbError(error)
+
+    return NextResponse.json(updated)
   } catch (err) {
     return safeCatchError(err)
   }

--- a/apps/web/lib/validation/schemas.ts
+++ b/apps/web/lib/validation/schemas.ts
@@ -116,6 +116,12 @@ export const mintSchema = z.object({
   { message: "reading_id or certificate_id required" }
 )
 
+// Update reading
+export const updateReadingSchema = z.object({
+  reading_id: uuid,
+  status: z.enum(["pending", "verified", "rejected"]),
+})
+
 // Retire
 export const retireSchema = z.object({
   certificate_id: uuid,


### PR DESCRIPTION
## Description

Implements validation to ensure certificates can only be created from verified readings, maintaining data integrity throughout the certification flow.

## Related Issue

Closes #128

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧪 Test addition/update

## Changes Made

- Added `updateReadingSchema` validation schema for PATCH endpoint
- Implemented PATCH `/api/readings` endpoint for admin to verify/reject readings
- Added verified readings validation in POST `/api/certificates` 
- Created 7 new comprehensive tests for reading verification workflow
- Updated certificate creation tests to include verification logic

## Checklist

- [x] My code follows the project's style guidelines (run `pnpm format`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (46/48 passing, 2 pre-existing failures)

## Testing Instructions

1. Checkout this branch: `git checkout feat/verify-readings-before-certificate`
2. Install dependencies: `pnpm install`
3. Run API tests: `cd apps/web && pnpm run test:api`
4. Verify all new tests pass:
   - PATCH /api/readings - 5 new tests
   - POST /api/certificates - 2 updated tests

### Manual Testing (API)

**Test 1: Verify a reading**
```bash
PATCH /api/readings
{
  "reading_id": "<uuid>",
  "status": "verified"
}
# Expected: 200, reading status updated
```

**Test 2: Try to create certificate without verified readings**
```bash
POST /api/certificates
{
  "cooperative_id": "<uuid>",
  "generation_period_start": "2025-01-01",
  "generation_period_end": "2025-01-31",
  "total_kwh": 150,
  "technology": "solar"
}
# Expected: 400 "No verified readings for this period"
```

**Test 3: Create certificate with verified readings**
```bash
# First verify a reading (Test 1), then:
POST /api/certificates
# Expected: 201, certificate created
```

## Additional Context

This implementation follows the project's existing patterns:
- Zod schemas for validation
- `requireAdmin` middleware for authorization
- `safeDbError` for error handling
- Comprehensive test coverage matching existing test files

The solution ensures data integrity by requiring admin verification before certificates can be created, preventing invalid or unverified generation data from being certified on-chain.