### PR TITLE
Fix: Add date range validation for certificates

### DIFF
--- a/apps/web/__tests__/api/certificates.test.ts
+++ b/apps/web/__tests__/api/certificates.test.ts
@@ -77,6 +77,37 @@ describe("POST /api/certificates", () => {
     expect(json.error).toMatch(/Validation failed/)
   })
 
+  it("rechaza fecha de inicio posterior a fecha de fin → 400", async () => {
+    const res = await POST(
+      makePost({
+        cooperative_id: COOP_ID,
+        generation_period_start: "2028-03-09",
+        generation_period_end: "2026-03-19",
+        total_kwh: 150,
+        technology: "solar",
+      })
+    )
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.error).toMatch(/Validation failed/)
+  })
+
+  it("acepta fechas iguales (mismo día) → 201", async () => {
+    const fakeCert = { id: "cert-2", cooperative_id: COOP_ID, total_kwh: 50, technology: "solar", status: "pending" }
+    mockSingle.mockResolvedValueOnce({ data: fakeCert, error: null })
+
+    const res = await POST(
+      makePost({
+        cooperative_id: COOP_ID,
+        generation_period_start: "2025-06-15",
+        generation_period_end: "2025-06-15",
+        total_kwh: 50,
+        technology: "solar",
+      })
+    )
+    expect(res.status).toBe(201)
+  })
+
   it("crea certificado válido → 201", async () => {
     const fakeCert = {
       id: "cert-1",

--- a/apps/web/components/modals/create-certificate-modal.tsx
+++ b/apps/web/components/modals/create-certificate-modal.tsx
@@ -43,6 +43,10 @@ export function CreateCertificateModal({ isOpen, onClose, cooperativeId, onSucce
 
   const handleSubmit = async () => {
     if (!periodStart || !periodEnd || !totalKwh) return
+    if (periodStart > periodEnd) {
+      setError(t("createCert.invalidDateRange"))
+      return
+    }
     setIsSubmitting(true)
     setError(null)
     try {

--- a/apps/web/lib/i18n-context.tsx
+++ b/apps/web/lib/i18n-context.tsx
@@ -328,6 +328,7 @@ const translations = {
     "createCert.location": "Ubicación (opcional)",
     "createCert.submit": "Crear Certificado",
     "createCert.success": "Certificado creado exitosamente",
+    "createCert.invalidDateRange": "La fecha de inicio debe ser anterior a la fecha de fin",
 
     // Retirar certificado
     "retire.title": "Retirar Certificado",
@@ -698,6 +699,7 @@ const translations = {
     "createCert.location": "Location (optional)",
     "createCert.submit": "Create Certificate",
     "createCert.success": "Certificate created successfully",
+    "createCert.invalidDateRange": "The start date must be before the end date",
 
     // Retire certificate
     "retire.title": "Retire Certificate",

--- a/apps/web/lib/validation/schemas.ts
+++ b/apps/web/lib/validation/schemas.ts
@@ -105,7 +105,10 @@ export const createCertificateSchema = z.object({
   total_kwh: z.number().positive(),
   technology: z.string().min(1),
   location: z.string().max(200).nullish(),
-})
+}).refine(
+  (d) => d.generation_period_start <= d.generation_period_end,
+  { message: "generation_period_start must be before or equal to generation_period_end" }
+)
 
 // Mint
 export const mintSchema = z.object({


### PR DESCRIPTION
## Description

Add date range validation to the certificate creation flow. Previously, the form accepted and submitted periods where the start date was later than the end date (e.g. start: 09/03/2028, end: 19/03/2026), creating certificates with inverted periods without any error feedback.

The fix adds validation at two layers: the frontend blocks submission and shows an inline error message, and the backend Zod schema rejects inverted ranges at the API level.

Resume: Enforce that generation_period_start is <= generation_period_end. Add a Zod refine rule to the createCertificateSchema, add a client-side check in the create-certificate modal that surfaces an i18n error, and include Spanish/English translations for the message. Tests were updated to reject a start date after the end date and to accept equal start/end dates.

## Related Issue

Closes #127 --> [BUG]: Certificate creation accepts invalid date range (start after end)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

- [x] 🧪 Test addition/update

## Changes Made

- apps/web/components/modals/create-certificate-modal.tsx --> Added periodStart > periodEnd check in handleSubmit; sets error state and blocks submission before the API call
- apps/web/lib/i18n-context.tsx --> Added createCert.invalidDateRange key to both ES ("La fecha de inicio debe ser anterior a la fecha de fin") and EN ("The start date must be before the end date")
- apps/web/lib/validation/schemas.ts --> Added .refine() to createCertificateSchema to reject requests where generation_period_start > generation_period_end with a 400 response
- apps/web/__tests__/api/certificates.test.ts --> Added two new test cases: rejects inverted date range (400) and accepts equal dates / same-day period (201)

## Checklist

- [x] My code follows the project's style guidelines (run `pnpm format`)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Testing Instructions

1. Checkout this branch: git checkout <branch-name>
2. Install dependencies: pnpm install
3. Start dev server: pnpm dev
4. Navigate to Mi Cooperativa --> Pipeline de Certificados
5. Click Crear Certificado
6. Enter a start date later than the end date (e.g. start: 2028-03-09, end: 2026-03-19)
7. Click Crear Certificado --> verify that an inline error appears: "La fecha de inicio debe ser anterior a la fecha de fin" and no certificate is created
8. Correct the dates (start ≤ end) and submit again --> verify the certificate is created normally
9. Run the API tests to confirm backend validation: cd apps/web && pnpm run test:api

Additional Context
Before:
Form submits with inverted dates, certificate appears in pipeline as "pending" with period "9 mar 2028 — 19 mar 2026"

After:
Form blocks submission and shows inline error: "La fecha de inicio debe ser anterior a la fecha de fin"

The date comparison uses standard ISO string comparison (YYYY-MM-DD), which works correctly for lexicographic ordering. Equal dates (same-day generation period) are explicitly allowed.

## For Bounty Issues

- [x] I have linked the bounty issue this PR resolves
- [x] All acceptance criteria from the issue are met
- [x] I have provided my Stellar address for bounty payout: `G...`

