### PR TITLE
fix(auth): handle 401 response silently to reduce console noise (#131)

### DIFF
--- a/apps/web/lib/auth-context.tsx
+++ b/apps/web/lib/auth-context.tsx
@@ -32,13 +32,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     async function checkSession() {
       try {
         const res = await fetch("/api/auth/me")
+        if (res.status === 401) {
+          setSession(null)
+          return
+        }
         if (res.ok) {
           const data = await res.json()
           setSession(data)
         } else {
+          console.error("Unexpected /api/auth/me error:", res.status)
           setSession(null)
         }
-      } catch {
+      } catch (err) {
+        console.error("Network error fetching /api/auth/me:", err)
         setSession(null)
       } finally {
         setIsLoading(false)


### PR DESCRIPTION
### Description
Handled 401 Unauthorized responses from `/api/auth/me` silently to remove unnecessary console noise during unauthenticated sessions.

### Changes
- **lib/auth-context.tsx**: Implemented an early return when `res.status === 401`.
- **Improved Logging**: Differentiated between expected unauthenticated states (401) and actual failures (5xx or network errors), which are now explicitly logged for better observability.

### Evidence
The screenshot shows the `/api/auth/me` request returning a 401 status in the Network tab, while the Console remains clear of "Failed to load resource" errors.

<img width="1920" height="1080" alt="beEnergy" src="https://github.com/user-attachments/assets/6f9bb2a7-6757-4068-90a7-08eac39d0149" />

Cualquier comentario o suguerencia es bienvenido, graciaas :) 

closes #131 