### PR TITLE
feat: explain pending reading status and add verify action for cooperative admin

### DIFF
--- a/apps/web/app/consumption/page.tsx
+++ b/apps/web/app/consumption/page.tsx
@@ -1,8 +1,9 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useState, useCallback } from "react"
 import { useRouter } from "next/navigation"
 import { useWallet } from "@/lib/wallet-context"
+import { useAuth } from "@/lib/auth-context"
 import { useI18n } from "@/lib/i18n-context"
 import { useMyReadings } from "@/hooks/useMyReadings"
 import { Sidebar } from "@/components/sidebar"
@@ -10,11 +11,11 @@ import { DashboardHeader } from "@/components/dashboard-header"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Spinner } from "@/components/ui/spinner"
-import { ArrowLeft, Zap, FileText, RefreshCw } from "lucide-react"
+import { ArrowLeft, Zap, FileText, RefreshCw, CheckCircle2 } from "lucide-react"
 import { InfoTooltip } from "@/components/shared/info-tooltip"
 
 const STATUS_TOOLTIP: Record<string, string> = {
-  pending: "Esta lectura fue registrada pero aún no fue revisada ni aprobada por la cooperativa.",
+  pending: "Esta lectura está pendiente de validación por el administrador de tu cooperativa.",
   verified: "La cooperativa revisó y confirmó que esta lectura es correcta.",
   certified: "Esta lectura fue certificada y registrada en la blockchain como proto-certificado de energía renovable.",
 }
@@ -27,15 +28,34 @@ const SOURCE_TOOLTIP: Record<string, string> = {
 
 export default function ConsumptionPage() {
   const { isConnected, address } = useWallet()
+  const { session } = useAuth()
   const { t } = useI18n()
   const router = useRouter()
   const { readings, loading, error, refetch } = useMyReadings(address)
+  const [verifying, setVerifying] = useState<Record<string, boolean>>({})
 
   useEffect(() => {
     if (!isConnected) {
       router.push("/")
     }
   }, [isConnected, router])
+
+  const verifyReading = useCallback(async (readingId: string) => {
+    setVerifying(prev => ({ ...prev, [readingId]: true }))
+    try {
+      await fetch("/api/readings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reading_id: readingId, status: "verified" }),
+      })
+      refetch()
+    } finally {
+      setVerifying(prev => ({ ...prev, [readingId]: false }))
+    }
+  }, [refetch])
+
+  const isAdminOf = (cooperativeId: string) =>
+    session?.admin_cooperative_ids.includes(cooperativeId) ?? false
 
   if (!isConnected) {
     return null
@@ -146,6 +166,7 @@ export default function ConsumptionPage() {
                                 ? "bg-web3-purple/10 text-web3-purple"
                                 : "bg-solar-yellow/10 text-solar-yellow"
                           }`}>
+                            {reading.status === "verified" && <CheckCircle2 className="w-3 h-3" />}
                             {reading.status}
                             {STATUS_TOOLTIP[reading.status] && <InfoTooltip text={STATUS_TOOLTIP[reading.status]} />}
                           </span>
@@ -154,6 +175,19 @@ export default function ConsumptionPage() {
                               {reading.source}
                               {SOURCE_TOOLTIP[reading.source] && <InfoTooltip text={SOURCE_TOOLTIP[reading.source]} />}
                             </span>
+                          )}
+                          {reading.status === "pending" && isAdminOf(reading.cooperative_id) && (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="h-6 px-2 text-xs"
+                              disabled={verifying[reading.id]}
+                              onClick={() => verifyReading(reading.id)}
+                            >
+                              {verifying[reading.id]
+                                ? <Spinner className="size-3" />
+                                : t("consumption.verify")}
+                            </Button>
                           )}
                         </div>
                       </div>

--- a/apps/web/lib/i18n-context.tsx
+++ b/apps/web/lib/i18n-context.tsx
@@ -228,6 +228,8 @@ const translations = {
     "consumption.total": "generados",
     "consumption.noData": "Sin datos de generación",
     "consumption.noDataDescription": "Los datos de generación se mostrarán cuando tu cooperativa registre lecturas de medidores.",
+    "consumption.verify": "Verificar",
+    "consumption.verifying": "Verificando...",
 
     // Dashboard Member
     "dashboard.myMeters": "Mis Medidores",
@@ -614,6 +616,8 @@ const translations = {
     "consumption.total": "generated",
     "consumption.noData": "No generation data",
     "consumption.noDataDescription": "Generation data will appear when your cooperative registers meter readings.",
+    "consumption.verify": "Verify",
+    "consumption.verifying": "Verifying...",
 
     // Dashboard Member
     "dashboard.myMeters": "My Meters",


### PR DESCRIPTION
## Description

Implements the UI improvements requested in issue #135. Pending readings now show a clear explanation of their status via an updated tooltip, and cooperative admins can verify pending readings directly from the Generation History page.

## Related Issue

Closes #135

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🎨 UI/UX improvement

## Changes Made

- Updated `STATUS_TOOLTIP.pending` in `app/consumption/page.tsx` to display "Esta lectura está pendiente de validación por el administrador de tu cooperativa."
- Added `useAuth` to `ConsumptionPage` to access `session.admin_cooperative_ids`
- Added a "Verificar" button that appears on pending readings only for cooperative admins, calling `PATCH /api/readings` to update status to `verified`
- Added `CheckCircle2` icon inside the verified reading badge for visual confirmation
- Added `consumption.verify` and `consumption.verifying` i18n keys for both Spanish and English

## Checklist

- [x] My code follows the project's style guidelines (run `pnpm format`)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes

## Testing Instructions

1. Checkout this branch: `git checkout feat/pending-reading-tooltip-and-verify-action`
2. Install dependencies: `pnpm install`
3. Start dev server: `pnpm dev`
4. Connect a wallet and navigate to **Generation History** (`/consumption`)
5. Verify that pending readings show the updated tooltip text explaining the validation requirement
6. Log in as a cooperative admin (a wallet whose address is in `admin_cooperative_ids`)
7. Verify that a "Verificar" button appears next to pending readings
8. Click "Verificar" and confirm the reading status updates to verified with a green checkmark badge

## Additional Context

The `PATCH /api/readings` backend endpoint was already implemented and properly restricts access to cooperative admins only. This PR adds only the missing frontend surface.

---

## For Bounty Issues

- [x] I have linked the bounty issue this PR resolves
- [x] All acceptance criteria from the issue are met
- [ ] I have tested on testnet with Freighter wallet (if applicable)
- [ ] I have provided my Stellar address for bounty payout: `G...`