### PR TITLE
fix(mint): use dynamic timebounds to prevent txTooLate on testnet

### DIFF
--- a/apps/web/app/api/certificates/retire/route.ts
+++ b/apps/web/app/api/certificates/retire/route.ts
@@ -54,10 +54,12 @@ export async function POST(req: NextRequest) {
     const minterPublic = minterKeypair.publicKey()
     const minterAccount = await server.getAccount(minterPublic)
     const contract = new StellarSdk.Contract(contractAddress)
-
+    const maxTime = Math.floor(Date.now() / 1000) + 300
+    
     const transaction = new StellarSdk.TransactionBuilder(minterAccount, {
       fee: "100000",
       networkPassphrase: NETWORK_PASSPHRASE,
+      timebounds: { minTime: 0, maxTime },
     })
       .addOperation(
         contract.call(
@@ -66,7 +68,6 @@ export async function POST(req: NextRequest) {
           StellarSdk.nativeToScVal(amountInStroops, { type: "i128" })
         )
       )
-      .setTimeout(30)
       .build()
 
     const preparedTx = await server.prepareTransaction(transaction)

--- a/apps/web/app/api/mint/route.ts
+++ b/apps/web/app/api/mint/route.ts
@@ -37,10 +37,12 @@ async function mintOnChain(
   const minterPublic = minterKeypair.publicKey()
   const minterAccount = await withRetry(() => server.getAccount(minterPublic), "getAccount")
   const contract = new StellarSdk.Contract(contractAddress)
+  const maxTime = Math.floor(Date.now() / 1000) + 300
 
   const transaction = new StellarSdk.TransactionBuilder(minterAccount, {
     fee: "100000",
     networkPassphrase: NETWORK_PASSPHRASE,
+    timebounds: { minTime: 0, maxTime },
   })
     .addOperation(
       contract.call(
@@ -50,7 +52,6 @@ async function mintOnChain(
         StellarSdk.nativeToScVal(minterPublic, { type: "address" })
       )
     )
-    .setTimeout(30)
     .build()
 
   const preparedTx = await withRetry(() => server.prepareTransaction(transaction), "prepareTransaction")


### PR DESCRIPTION
## Description

Fixes `txTooLate` error that caused mint and retire transactions to fail on testnet.

## Related Issue

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] ♻️ Code refactoring
- [ ] 🧪 Test addition/update

## Changes Made

- Replaced hardcoded `.setTimeout(30)` with dynamic `timebounds` in `/api/mint/route.ts`
- Replaced hardcoded `.setTimeout(250)` with dynamic `timebounds` in `/api/certificates/retire/route.ts`

## Checklist

- [x] My code follows the project's style guidelines (run `pnpm format`)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Testing Instructions

<!-- How should reviewers test this PR? -->

1. Checkout this branch: `git checkout fix/mint-retire-timeout`
2. Install dependencies: `pnpm install`
3. Start dev server: `pnpm dev`
4. Go to `/dashboard/cooperative`
5. Click "Mintear" on a pending certificate — should succeed
6. Go to `/certificates`, click "Retirar Certificado" — should succeed


## For Bounty Issues

- [ ] I have linked the bounty issue this PR resolves
- [ ] All acceptance criteria from the issue are met
- [ ] I have tested on testnet with Freighter wallet (if applicable)
- [ ] I have provided my Stellar address for bounty payout: `G...`

