### PR TITLE
fix(web): mount global toaster and trigger persistent notifications on success

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -7,6 +7,7 @@ import { WalletProvider } from "@/lib/wallet-context"
 import { AuthProvider } from "@/lib/auth-context"
 import { ThemeProvider } from "@/lib/theme-context"
 import { I18nProvider } from "@/lib/i18n-context"
+import { Toaster } from "@/components/ui/sonner"
 
 const inter = Inter({
   subsets: ["latin"],
@@ -44,6 +45,7 @@ export default function RootLayout({
             </WalletProvider>
           </I18nProvider>
         </ThemeProvider>
+        <Toaster richColors position="top-right" />
         <Analytics />
       </body>
     </html>

--- a/apps/web/components/modals/add-meter-modal.tsx
+++ b/apps/web/components/modals/add-meter-modal.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { toast } from "sonner"
 import { useI18n } from "@/lib/i18n-context"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -71,6 +72,7 @@ export function AddMeterModal({ isOpen, onClose, cooperativeId, onSuccess }: Add
         }
         throw new Error(errorMessages[data.error] || data.error || "Error al agregar el medidor")
       }
+      toast.success("Medidor agregado correctamente")
       setSuccess(true)
       onSuccess()
       setTimeout(handleClose, 1500)

--- a/apps/web/components/modals/add-meter-modal.tsx
+++ b/apps/web/components/modals/add-meter-modal.tsx
@@ -72,7 +72,7 @@ export function AddMeterModal({ isOpen, onClose, cooperativeId, onSuccess }: Add
         }
         throw new Error(errorMessages[data.error] || data.error || "Error al agregar el medidor")
       }
-      toast.success("Medidor agregado correctamente")
+      toast.success(t("addMeter.success"))
       setSuccess(true)
       onSuccess()
       setTimeout(handleClose, 1500)

--- a/apps/web/components/modals/submit-reading-modal.tsx
+++ b/apps/web/components/modals/submit-reading-modal.tsx
@@ -75,7 +75,7 @@ export function SubmitReadingModal({ isOpen, onClose, cooperativeId, meters, onS
         const data = await res.json()
         throw new Error(data.error || "Failed to submit reading")
       }
-      toast.success("Lectura enviada correctamente")
+      toast.success(t("submitReading.success"))
       setSuccess(true)
       onSuccess()
       setTimeout(handleClose, 1500)

--- a/apps/web/components/modals/submit-reading-modal.tsx
+++ b/apps/web/components/modals/submit-reading-modal.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { toast } from "sonner"
 import { useI18n } from "@/lib/i18n-context"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -74,6 +75,7 @@ export function SubmitReadingModal({ isOpen, onClose, cooperativeId, meters, onS
         const data = await res.json()
         throw new Error(data.error || "Failed to submit reading")
       }
+      toast.success("Lectura enviada correctamente")
       setSuccess(true)
       onSuccess()
       setTimeout(handleClose, 1500)


### PR DESCRIPTION
### Description
Thanks for the issue. This PR fixes the UX inconsistency where the "Add Meter" modal was closing silently. 

Both the "Add Meter" and "Submit Reading" modals relied on inline success banners that disappeared instantly when the modal unmounted after 1.5 seconds. To resolve this, I uncoupled the notification lifecycle from the modal subtrees by mounting the global `<Toaster />` at the root layout level and integrating persistent toast notifications that respect the active i18n locale.

### Changes
* **`apps/web/app/layout.tsx`**: Mounted Sonner's `<Toaster richColors position="top-right" />` inside the global body tag.
* **`apps/web/components/modals/add-meter-modal.tsx`**: Integrated `toast.success(t("addMeter.success"))` right before the close timer, matching the exact wording and supporting `es` / `en` locales dynamically.
* **`apps/web/components/modals/submit-reading-modal.tsx`**: Applied the exact same pattern for strict parity using `toast.success(t("submitReading.success"))`.

Let me know if you prefer any modifications or further tweaks. Ready to adjust whatever is needed!

closes #158 