### PR TITLE
fix(web): fetch and display real cooperative member count in admin dashboard

### DIFF
--- a/apps/web/app/api/admin/stats/route.ts
+++ b/apps/web/app/api/admin/stats/route.ts
@@ -14,10 +14,10 @@ export async function GET() {
       .select("*")
       .order("created_at", { ascending: false })
 
-    // All prosumers count
-    const { count: memberCount } = await supabase
+    // All prosumers — full rows needed for per-cooperative grouping; count kept for global total
+    const { data: prosumers, count: memberCount } = await supabase
       .from("prosumers")
-      .select("id", { count: "exact", head: true })
+      .select("id, cooperative_id", { count: "exact" })
 
     // All certificates
     const { data: certificates } = await supabase
@@ -33,6 +33,7 @@ export async function GET() {
       const coopCerts = certs.filter((c) => c.cooperative_id === coop.id)
       return {
         ...coop,
+        member_count: (prosumers ?? []).filter((p) => p.cooperative_id === coop.id).length,
         certificates_count: coopCerts.length,
         total_kwh: coopCerts.reduce((sum, c) => sum + (c.total_kwh || 0), 0),
         pending: coopCerts.filter((c) => c.status === "pending").length,

--- a/apps/web/app/dashboard/admin/page.tsx
+++ b/apps/web/app/dashboard/admin/page.tsx
@@ -145,7 +145,7 @@ export default function SuperAdminPage() {
                               <td className="py-3 font-medium">{coop.name}</td>
                               <td className="py-3">{coop.technology}</td>
                               <td className="py-3">{coop.province || "—"}</td>
-                              <td className="py-3">{coop.certificates_count > 0 ? "—" : "—"}</td>
+                              <td className="py-3">{coop.member_count}</td>
                               <td className="py-3">{coop.certificates_count}</td>
                               <td className="py-3">{coop.total_kwh.toLocaleString()}</td>
                               <td className="py-3"><StatusBadge status={coop.status} /></td>

--- a/apps/web/hooks/useAdminStats.ts
+++ b/apps/web/hooks/useAdminStats.ts
@@ -21,6 +21,7 @@ export interface AdminStats {
     status: string
     admin_stellar_address: string
     created_at: string
+    member_count: number
     certificates_count: number
     total_kwh: number
     pending: number


### PR DESCRIPTION
### Description
Thanks for the issue. This PR fixes the admin dashboard bug where the "Miembros" column for all cooperatives was hardcoded to display "—".

### Diagnosis
The backend route `/api/admin/stats` was fetching prosumers using Supabase's `{ head: true, count: 'exact' }` configuration. While this correctly populated the global member totals, it completely discarded the rows from the response payload, making it impossible to aggregate members by cooperative in the subsequent `.map()` iteration. Additionally, the frontend cell contained a dead placeholder ternary (`coop.certificates_count > 0 ? "—" : "—"`).

### Changes
* **`apps/web/app/api/admin/stats/route.ts`**: Replaced the `head: true` query with a clean column select (`"id, cooperative_id"`) while maintaining the destructured total count. Injected the `member_count` field into the cooperative stats mapping using memory-efficient JS filtering.
* **`apps/web/hooks/useAdminStats.ts`**: Updated the `AdminStats` interface to include `member_count: number` within the cooperative structure, extending type safety down to the component layer.
* **`apps/web/app/dashboard/admin/page.tsx`**: Removed the dead ternary and replaced it with the dynamic `{coop.member_count}` evaluation.

closes #160 