### PR TITLE
fix: add pending stat card as status filter in certificates page (#157)

### DIFF
--- a/apps/web/app/api/certificates/stats/route.ts
+++ b/apps/web/app/api/certificates/stats/route.ts
@@ -34,6 +34,7 @@ export async function GET(req: NextRequest) {
   const totalKwhRetired = (retirements ?? []).reduce((s, r) => s + r.kwh_retired, 0)
 
   const certificatesAvailable = (allCerts ?? []).filter((c) => c.status === "available").length
+  const certificatesPending = (allCerts ?? []).filter((c) => c.status === "pending").length
   const certificatesRetired = (allCerts ?? []).filter(
     (c) => c.status === "retired" || retiredCertIds.has(c.id)
   ).length
@@ -77,6 +78,7 @@ export async function GET(req: NextRequest) {
     total_kwh_retired: Math.round(totalKwhRetired * 100) / 100,
     co2_avoided_kg: Math.round(totalKwhRetired * CO2_FACTOR_AR * 100) / 100,
     certificates_available: certificatesAvailable,
+    certificates_pending: certificatesPending,
     certificates_retired: certificatesRetired,
     by_technology: byTechnology,
     by_cooperative: byCooperative,

--- a/apps/web/app/certificates/page.tsx
+++ b/apps/web/app/certificates/page.tsx
@@ -10,7 +10,7 @@ import { DashboardHeader } from "@/components/dashboard-header"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { ArrowLeft, Award, Zap, Flame, Leaf, ExternalLink, ChevronDown, ChevronUp, AlertCircle } from "lucide-react"
+import { ArrowLeft, Award, Zap, Flame, Leaf, Clock, ExternalLink, ChevronDown, ChevronUp, AlertCircle } from "lucide-react"
 import { InfoTooltip } from "@/components/shared/info-tooltip"
 import { Spinner } from "@/components/ui/spinner"
 import { useAuth } from "@/lib/auth-context"
@@ -168,7 +168,7 @@ export default function CertificatesPage() {
   });
 
   const handleStatusQuickFilter = (
-    nextStatus: "all" | "available" | "retired",
+    nextStatus: "all" | "pending" | "available" | "retired",
   ) => {
     if (nextStatus === "all") {
       setStatusFilter("all");
@@ -216,7 +216,7 @@ export default function CertificatesPage() {
 
           {/* Compact Stats */}
           {stats && !statsError && (
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3">
               <CertificateStatCard
                 value={stats.total_kwh_certified.toLocaleString()}
                 label={t("certificates.stats.certified")}
@@ -248,6 +248,18 @@ export default function CertificatesPage() {
                 icon={<Leaf className="w-5 h-5 text-web3-purple" />}
                 containerClassName="bg-web3-purple/10 border-web3-purple/20"
                 valueClassName="text-web3-purple"
+              />
+
+              <CertificateStatCard
+                value={stats.certificates_pending}
+                label={t("certificates.stats.pending")}
+                tooltip={t("certificates.tooltip.pending")}
+                icon={<Clock className="w-5 h-5 text-blue-500" />}
+                containerClassName="bg-blue-500/10 border-blue-500/20"
+                valueClassName="text-blue-500"
+                interactive
+                isActive={statusFilter === "pending"}
+                onClick={() => handleStatusQuickFilter("pending")}
               />
 
               <CertificateStatCard

--- a/apps/web/hooks/useCertificateStats.ts
+++ b/apps/web/hooks/useCertificateStats.ts
@@ -7,6 +7,7 @@ export interface CertificateStats {
   total_kwh_retired: number
   co2_avoided_kg: number
   certificates_available: number
+  certificates_pending: number
   certificates_retired: number
   by_technology: Record<string, { certified_kwh: number; retired_kwh: number }>
   by_cooperative: Record<string, { name: string; certified_kwh: number; retired_kwh: number }>

--- a/apps/web/lib/i18n-context.tsx
+++ b/apps/web/lib/i18n-context.tsx
@@ -120,6 +120,7 @@ const translations = {
     "certificates.stats.retired": "kWh Retirados",
     "certificates.stats.co2": "CO₂ Evitado (kg)",
     "certificates.stats.available": "Disponibles",
+    "certificates.stats.pending": "Pendientes",
     "certificates.status.pending": "Pendiente",
     "certificates.status.available": "Disponible",
     "certificates.status.retired": "Retirado",
@@ -137,6 +138,7 @@ const translations = {
     "certificates.tooltip.retired": "kWh cuyo certificado fue comprado y retirado (quemado on-chain)",
     "certificates.tooltip.co2": "Estimación de CO₂ evitado basada en 0.4 kg CO₂ por kWh renovable",
     "certificates.tooltip.available": "Certificados emitidos que aún no fueron comprados",
+    "certificates.tooltip.pending": "Certificados pendientes de emisión en blockchain",
 
     // Wallet Confirmation Modal
     "wallet.title": "Conectar Wallet",
@@ -509,6 +511,7 @@ const translations = {
     "certificates.stats.retired": "kWh Retired",
     "certificates.stats.co2": "CO₂ Avoided (kg)",
     "certificates.stats.available": "Available",
+    "certificates.stats.pending": "Pending",
     "certificates.status.pending": "Pending",
     "certificates.status.available": "Available",
     "certificates.status.retired": "Retired",
@@ -526,6 +529,7 @@ const translations = {
     "certificates.tooltip.retired": "kWh whose certificate was purchased and retired (burned on-chain)",
     "certificates.tooltip.co2": "CO₂ avoided estimate based on 0.4 kg CO₂ per renewable kWh",
     "certificates.tooltip.available": "Issued certificates not yet purchased",
+    "certificates.tooltip.pending": "Certificates pending issuance on blockchain",
 
     // Wallet Confirmation Modal
     "wallet.title": "Connect Wallet",


### PR DESCRIPTION
## Description

Adds a "Pending" stat card to the certificates page that works as a quick filter, consistent with the existing "Retired" and "Available" cards. Previously the only way to filter by pending status was through the dropdown.

## Related Issue

Closes #157 

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `apps/web/app/api/certificates/stats/route.ts`: adds `certificates_pending` to the `/api/certificates/stats` response
- `apps/web/hooks/useCertificateStats.ts`: adds `certificates_pending: number` to the `CertificateStats` interface
- `apps/web/lib/i18n-context.tsx`: adds `certificates.stats.pending` and `certificates.tooltip.pending` keys in ES and EN
- `apps/web/app/certificates/page.tsx`: adds "Pending" stat card with Clock icon, blue color, toggle filter, and 5-column grid

## Checklist

- [x] My changes follow the existing code style
- [x] I have tested my changes locally
- [x] No new dependencies added

## Screenshots (if applicable)

**Before:**
<img width="1306" height="591" alt="image" src="https://github.com/user-attachments/assets/09644be7-8f1d-494a-8ca5-df97805d6e53" />


**After:**
<img width="1322" height="595" alt="Captura de pantalla 2026-06-01 192209" src="https://github.com/user-attachments/assets/e174cb76-3a41-49fa-9e48-6519f4896210" />
