### PR TITLE
fix: add missing .order() and .single() mocks in API tests (#159)

### DIFF
--- a/apps/web/__tests__/api/certificates.test.ts
+++ b/apps/web/__tests__/api/certificates.test.ts
@@ -7,7 +7,7 @@ const COOP_ID = "00000000-0000-0000-0000-000000000001"
 const { mockSingle, mockOrder, mockFrom, mockLimit } = vi.hoisted(() => {
   const mockSingle = vi.fn()
   const mockLimit = vi.fn(() => ({ data: [] as unknown[], error: null }))
-  const mockOrder = vi.fn(() => ({ data: [], error: null }))
+  const mockOrder = vi.fn(() => ({ data: [], error: null, single: mockSingle, order: mockOrder, eq: mockEq, gte: mockEq, lte: mockEq, limit: mockLimit }))
   const mockEq: ReturnType<typeof vi.fn> = vi.fn(() => ({
     order: mockOrder,
     eq: mockEq,

--- a/apps/web/__tests__/api/meters.test.ts
+++ b/apps/web/__tests__/api/meters.test.ts
@@ -8,7 +8,7 @@ const { mockSingle, mockOrder, mockIn, mockFrom } = vi.hoisted(() => {
   const mockSingle = vi.fn()
   const mockIn = vi.fn(() => ({ data: [], error: null }))
   const mockOrder = vi.fn(() => ({ data: [], error: null, in: mockIn }))
-  const mockEq: ReturnType<typeof vi.fn> = vi.fn(() => ({ order: mockOrder, eq: mockEq, in: mockIn }))
+  const mockEq: ReturnType<typeof vi.fn> = vi.fn(() => ({ single: mockSingle, order: mockOrder, eq: mockEq, in: mockIn }))
   const mockSelect = vi.fn(() => ({ single: mockSingle }))
   const mockInsert = vi.fn(() => ({ select: mockSelect }))
   const mockFrom = vi.fn(() => ({
@@ -107,6 +107,7 @@ describe("POST /api/meters", () => {
       technology: "solar",
       capacity_kw: 5,
     }
+    mockSingle.mockResolvedValueOnce({ data: { id: "prosumer-id" }, error: null })
     mockSingle.mockResolvedValueOnce({ data: fakeMeter, error: null })
 
     const res = await POST(


### PR DESCRIPTION
## Description
Two API tests were failing due to incomplete Supabase mock chains, leaving the test suite at 49/50.

## Related Issue
Closes #159 

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes Made
- `apps/web/__tests__/api/meters.test.ts`: adds `single: mockSingle` to `mockEq` return so `.eq(...).single()` works in the prosumer lookup chain. Also adds a second `mockResolvedValueOnce` since `POST /api/meters` calls `.single()` twice (prosumer lookup + meter insert)
- `apps/web/__tests__/api/certificates.test.ts`: makes `mockOrder` return a chainable object with `.single`, `.order`, `.eq`, `.gte`, `.lte`, `.limit` so further chaining works when `GET /api/certificates` receives query params

## Checklist
- [x] My code follows the project's style guidelines (run `pnpm format`)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes


## Testing Instructions
1. Checkout this branch: `git checkout fix/159-api-test-mocks`
2. Install dependencies: `pnpm install`
3. Run: `cd apps/web && pnpm run test:api`
4. Verify that all 50/50 tests pass

## Screenshots (if applicable)

**Test results: 50/50 passing**
<img width="1145" height="510" alt="Captura de pantalla 2026-06-01 212317" src="https://github.com/user-attachments/assets/198b2ccc-9003-442c-beb4-8f599ed43e4b" />


## Additional Context
`POST /api/meters` calls `.single()` twice (prosumer lookup + meter insert), 
but only one return value was mocked.

## For Bounty Issues
- [x] I have linked the bounty issue this PR resolves
- [x] All acceptance criteria from the issue are met

