### PR TITLE
fix(web): apply rate limiting to auth endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 [![Deployed on Vercel](https://img.shields.io/badge/deployed-vercel-black)](https://be-energy-six.vercel.app)
 [![Docs](https://img.shields.io/badge/docs-GitBook-blue)](https://marias-organization-50.gitbook.io/beenergy/)
-[![Stellar Wave](https://img.shields.io/badge/Stellar-Wave%20%232-blueviolet)](https://www.drips.network/wave)
-[![DoraHacks](https://img.shields.io/badge/DoraHacks-Featured-orange)](https://dorahacks.io/buidl/36793)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 
 BeEnergy is a cooperative management dashboard + on-chain certification infrastructure for renewable energy on Stellar. Cooperatives use the dashboard to manage members, meters, readings, and statistics — and BeEnergy tokenizes their production as proto-certificates sold to external buyers (companies, ESG funds, climate programs).

--- a/apps/web/__tests__/api/auth-challenge.test.ts
+++ b/apps/web/__tests__/api/auth-challenge.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const ADDR = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+const { mockRpc, mockCheckRateLimit } = vi.hoisted(() => {
+  const mockRpc = vi.fn();
+  const mockCheckRateLimit = vi.fn(async () => null);
+  return { mockRpc, mockCheckRateLimit };
+});
+
+const { mockFrom, mockSingle } = vi.hoisted(() => {
+  const mockSingle = vi.fn();
+  const mockEq: ReturnType<typeof vi.fn> = vi.fn(() => ({
+    single: mockSingle,
+    eq: mockEq,
+  }));
+  const mockDelete = vi.fn(() => ({ lt: vi.fn(() => ({})) }));
+  const mockInsert = vi.fn(() => ({ error: null }));
+  const mockFrom = vi.fn(() => ({
+    delete: mockDelete,
+    insert: mockInsert,
+    select: vi.fn(() => ({ eq: mockEq })),
+  }));
+  return { mockFrom, mockSingle };
+});
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: { from: mockFrom, rpc: mockRpc },
+}));
+
+vi.mock("@/lib/auth/stellar-verify", () => ({
+  isValidStellarAddress: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: mockCheckRateLimit,
+  getClientIp: vi.fn(() => "127.0.0.1"),
+}));
+
+import { POST } from "@/app/api/auth/challenge/route";
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/auth/challenge", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/auth/challenge", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 400 when stellar_address is missing", async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 429 with Retry-After when IP rate limit is exceeded", async () => {
+    const { NextResponse } = await import("next/server");
+    mockCheckRateLimit.mockResolvedValueOnce(
+      NextResponse.json(
+        { error: "Too many requests" },
+        {
+          status: 429,
+          headers: { "Retry-After": "60" },
+        },
+      ),
+    );
+
+    const res = await POST(makeRequest({ stellar_address: ADDR }));
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("60");
+  });
+
+  it("returns 200 for a single request under the limit (no false positives)", async () => {
+    mockCheckRateLimit.mockResolvedValueOnce(null);
+    mockFrom.mockReturnValueOnce({
+      delete: vi.fn(() => ({ lt: vi.fn(() => ({})) })),
+    });
+    mockFrom.mockReturnValueOnce({ insert: vi.fn(() => ({ error: null })) });
+
+    const res = await POST(makeRequest({ stellar_address: ADDR }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toHaveProperty("challenge");
+  });
+});

--- a/apps/web/__tests__/api/auth-verify.test.ts
+++ b/apps/web/__tests__/api/auth-verify.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const ADDR = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const CHALLENGE = "abc123";
+const SIG = "sig";
+
+const { mockCheckRateLimit } = vi.hoisted(() => {
+  const mockCheckRateLimit = vi.fn(async () => null);
+  return { mockCheckRateLimit };
+});
+
+const { mockFrom, mockSingle } = vi.hoisted(() => {
+  const mockSingle = vi.fn();
+  const mockEq: ReturnType<typeof vi.fn> = vi.fn(() => ({
+    single: mockSingle,
+    eq: mockEq,
+  }));
+  const mockDelete = vi.fn(() => ({ eq: vi.fn(() => ({})) }));
+  const mockFrom = vi.fn(() => ({
+    select: vi.fn(() => ({ eq: mockEq })),
+    delete: mockDelete,
+  }));
+  return { mockFrom, mockSingle };
+});
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: { from: mockFrom },
+}));
+
+vi.mock("@/lib/auth/stellar-verify", () => ({
+  isValidStellarAddress: vi.fn(() => true),
+  verifySignature: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/auth/roles", () => ({
+  resolveRoles: vi.fn(async () => ({
+    cooperative_ids: [],
+    admin_cooperative_ids: [],
+  })),
+}));
+
+vi.mock("@/lib/auth/jwt", () => ({
+  signJWT: vi.fn(async () => "token"),
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  setSessionCookie: vi.fn((res) => res),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: mockCheckRateLimit,
+  getClientIp: vi.fn(() => "127.0.0.1"),
+}));
+
+import { POST } from "@/app/api/auth/verify/route";
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/auth/verify", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  stellar_address: ADDR,
+  challenge: CHALLENGE,
+  signature: SIG,
+};
+
+describe("POST /api/auth/verify", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 429 with Retry-After when IP rate limit is exceeded", async () => {
+    const { NextResponse } = await import("next/server");
+    mockCheckRateLimit.mockResolvedValueOnce(
+      NextResponse.json(
+        { error: "Too many requests" },
+        {
+          status: 429,
+          headers: { "Retry-After": "60" },
+        },
+      ),
+    );
+
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("60");
+  });
+
+  it("returns 429 with Retry-After when per-wallet rate limit is exceeded", async () => {
+    const { NextResponse } = await import("next/server");
+    // IP check passes, wallet check fails
+    mockCheckRateLimit.mockResolvedValueOnce(null).mockResolvedValueOnce(
+      NextResponse.json(
+        { error: "Too many requests" },
+        {
+          status: 429,
+          headers: { "Retry-After": "60" },
+        },
+      ),
+    );
+
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("60");
+  });
+
+  it("returns 200 for a single request under the limit (no false positives)", async () => {
+    mockCheckRateLimit.mockResolvedValue(null);
+    mockSingle.mockResolvedValueOnce({
+      data: {
+        id: "id-1",
+        stellar_address: ADDR,
+        challenge: CHALLENGE,
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+      },
+      error: null,
+    });
+
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 400 when required fields are missing", async () => {
+    mockCheckRateLimit.mockResolvedValue(null);
+    const res = await POST(makeRequest({ stellar_address: ADDR }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/app/api/auth/challenge/route.ts
+++ b/apps/web/app/api/auth/challenge/route.ts
@@ -1,43 +1,51 @@
-import { NextRequest, NextResponse } from "next/server"
-import { randomBytes } from "crypto"
-import { supabase } from "@/lib/supabase"
-import { isValidStellarAddress } from "@/lib/auth/stellar-verify"
+import { NextRequest, NextResponse } from "next/server";
+import { randomBytes } from "crypto";
+import { supabase } from "@/lib/supabase";
+import { isValidStellarAddress } from "@/lib/auth/stellar-verify";
+import { checkRateLimit, getClientIp } from "@/lib/rate-limit";
 
 export async function POST(req: NextRequest) {
+  const ip = getClientIp(req);
+  const rateLimitResponse = await checkRateLimit(ip, "auth/challenge");
+  if (rateLimitResponse) return rateLimitResponse;
+
   try {
-    const body = await req.json()
-    const { stellar_address } = body
+    const body = await req.json();
+    const { stellar_address } = body;
 
     if (!stellar_address || !isValidStellarAddress(stellar_address)) {
       return NextResponse.json(
         { error: "Valid stellar_address required" },
-        { status: 400 }
-      )
+        { status: 400 },
+      );
     }
 
     // Generate random challenge
-    const challenge = randomBytes(32).toString("hex")
-    const expires_at = new Date(Date.now() + 5 * 60 * 1000).toISOString() // 5 min TTL
+    const challenge = randomBytes(32).toString("hex");
+    const expires_at = new Date(Date.now() + 5 * 60 * 1000).toISOString(); // 5 min TTL
 
     // Clean expired challenges first
     await supabase
       .from("auth_challenges")
       .delete()
-      .lt("expires_at", new Date().toISOString())
+      .lt("expires_at", new Date().toISOString());
 
     // Store challenge
     const { error } = await supabase.from("auth_challenges").insert({
       stellar_address,
       challenge,
       expires_at,
-    })
+    });
 
     if (error) {
-      return NextResponse.json({ error: "Failed to create challenge" }, { status: 500 })
+      return NextResponse.json(
+        { error: "Failed to create challenge" },
+        { status: 500 },
+      );
     }
 
-    return NextResponse.json({ challenge })
+    return NextResponse.json({ challenge });
   } catch {
-    return NextResponse.json({ error: "Invalid request" }, { status: 400 })
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
   }
 }

--- a/apps/web/app/api/auth/verify/route.ts
+++ b/apps/web/app/api/auth/verify/route.ts
@@ -1,25 +1,43 @@
-import { NextRequest, NextResponse } from "next/server"
-import { supabase } from "@/lib/supabase"
-import { isValidStellarAddress, verifySignature } from "@/lib/auth/stellar-verify"
-import { resolveRoles } from "@/lib/auth/roles"
-import { signJWT } from "@/lib/auth/jwt"
-import { setSessionCookie } from "@/lib/auth/session"
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import {
+  isValidStellarAddress,
+  verifySignature,
+} from "@/lib/auth/stellar-verify";
+import { resolveRoles } from "@/lib/auth/roles";
+import { signJWT } from "@/lib/auth/jwt";
+import { setSessionCookie } from "@/lib/auth/session";
+import { checkRateLimit, getClientIp } from "@/lib/rate-limit";
 
 export async function POST(req: NextRequest) {
+  const ip = getClientIp(req);
+  const ipLimit = await checkRateLimit(ip, "auth/verify");
+  if (ipLimit) return ipLimit;
+
   try {
-    const body = await req.json()
-    const { stellar_address, challenge, signature } = body
+    const body = await req.json();
+    const { stellar_address, challenge, signature } = body;
 
     if (!stellar_address || !challenge || !signature) {
       return NextResponse.json(
-        { error: "Missing required fields: stellar_address, challenge, signature" },
-        { status: 400 }
-      )
+        {
+          error:
+            "Missing required fields: stellar_address, challenge, signature",
+        },
+        { status: 400 },
+      );
     }
 
     if (!isValidStellarAddress(stellar_address)) {
-      return NextResponse.json({ error: "Invalid stellar_address" }, { status: 400 })
+      return NextResponse.json(
+        { error: "Invalid stellar_address" },
+        { status: 400 },
+      );
     }
+
+    // Per-wallet rate limit (5 attempts per minute per address)
+    const walletLimit = await checkRateLimit(stellar_address, "auth/verify");
+    if (walletLimit) return walletLimit;
 
     // Lookup challenge
     const { data: stored, error: lookupError } = await supabase
@@ -27,35 +45,38 @@ export async function POST(req: NextRequest) {
       .select("*")
       .eq("challenge", challenge)
       .eq("stellar_address", stellar_address)
-      .single()
+      .single();
 
     if (lookupError || !stored) {
-      return NextResponse.json({ error: "Invalid or expired challenge" }, { status: 401 })
+      return NextResponse.json(
+        { error: "Invalid or expired challenge" },
+        { status: 401 },
+      );
     }
 
     // Check expiry
     if (new Date(stored.expires_at) < new Date()) {
-      await supabase.from("auth_challenges").delete().eq("id", stored.id)
-      return NextResponse.json({ error: "Challenge expired" }, { status: 401 })
+      await supabase.from("auth_challenges").delete().eq("id", stored.id);
+      return NextResponse.json({ error: "Challenge expired" }, { status: 401 });
     }
 
     // Verify signature
     if (!verifySignature(stellar_address, challenge, signature)) {
-      return NextResponse.json({ error: "Invalid signature" }, { status: 401 })
+      return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
     }
 
     // Delete used challenge
-    await supabase.from("auth_challenges").delete().eq("id", stored.id)
+    await supabase.from("auth_challenges").delete().eq("id", stored.id);
 
     // Resolve roles
-    const roles = await resolveRoles(stellar_address)
+    const roles = await resolveRoles(stellar_address);
 
     // Check super admin
     const superAdminAddresses = (process.env.SUPER_ADMIN_ADDRESSES || "")
       .split(",")
       .map((a) => a.trim())
-      .filter(Boolean)
-    const is_super_admin = superAdminAddresses.includes(stellar_address)
+      .filter(Boolean);
+    const is_super_admin = superAdminAddresses.includes(stellar_address);
 
     // Sign JWT
     const token = await signJWT({
@@ -63,7 +84,7 @@ export async function POST(req: NextRequest) {
       cooperative_ids: roles.cooperative_ids,
       admin_cooperative_ids: roles.admin_cooperative_ids,
       is_super_admin,
-    })
+    });
 
     // Set cookie and return session info
     const response = NextResponse.json({
@@ -71,10 +92,10 @@ export async function POST(req: NextRequest) {
       cooperative_ids: roles.cooperative_ids,
       admin_cooperative_ids: roles.admin_cooperative_ids,
       is_super_admin,
-    })
+    });
 
-    return setSessionCookie(response, token)
+    return setSessionCookie(response, token);
   } catch {
-    return NextResponse.json({ error: "Invalid request" }, { status: 400 })
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
   }
 }

--- a/docs/next-steps/analisis-flujo-cooperativa-vs-erd.md
+++ b/docs/next-steps/analisis-flujo-cooperativa-vs-erd.md
@@ -1,0 +1,124 @@
+# BeEnergy — Análisis de Coherencia: Flujo Ingreso Cooperativa vs ERD
+**Fecha:** Mayo 2026  
+**Preparado por:** romina-iurchik  
+**Para:** el equipo (Tech Lead)  
+**Contexto:** Revisión del flujo de ingreso de una cooperativa contra el modelo relacional actual
+
+---
+
+## Objetivo
+
+Verificar que cada paso del flujo de ingreso de una cooperativa tiene soporte correcto en el ERD. Los gaps identificados son decisiones de diseño que hay que tomar antes de avanzar con UX/UI.
+
+---
+
+## Flujo analizado
+
+```
+Conectar wallet → Setup perfil → Registrar cooperativa → 
+Agregar miembros → Registrar medidores → Cargar lecturas
+```
+
+---
+
+## Análisis paso a paso
+
+### ✅ Paso 1 — Conectar wallet / Setup perfil
+**Tabla:** `prosumers`  
+**Campo clave:** `stellar_address` — tiene UNIQUE constraint  
+**Estado:** OK. El modelo soporta correctamente la identidad del usuario.
+
+---
+
+### ⚠️ Paso 2 — Registrar cooperativa
+**Tabla:** `cooperatives`  
+**Endpoint:** `POST /api/cooperatives`  
+**Campos:** `name`, `technology`, `admin_stellar_address`, `country`, `province`, `city`
+
+**Gap identificado:**  
+`admin_stellar_address` es texto libre sin FK a `prosumers.stellar_address`. El administrador de la cooperativa no está formalmente vinculado como prosumidor en el modelo — son dos registros independientes sin relación declarada.
+
+**Pregunta para el equipo:**  
+¿El admin de una cooperativa siempre tiene que ser un prosumidor registrado, o puede ser un usuario externo que solo administra?
+
+**Impacto en UX/UI:**  
+Si el admin no es un prosumidor, no aparece en la lista de miembros. Esto puede confundir al usuario que espera verse a sí mismo en su propia cooperativa.
+
+---
+
+### ⚠️ Paso 3 — Agregar miembros
+**Tabla:** `prosumers`  
+**Endpoint:** `POST /api/members`  
+**Campo clave:** `cooperative_id` — una sola FK
+
+**Gap identificado:**  
+Un prosumidor solo puede pertenecer a **una** cooperativa. El modelo no soporta membresías múltiples. Si un usuario tiene paneles en dos cooperativas distintas, hoy no puede estar en ambas.
+
+**Pregunta para el equipo:**  
+¿Es un requisito que un prosumidor pueda pertenecer a más de una cooperativa? Si sí, necesitamos una tabla intermedia `cooperative_members` con la relación many-to-many.
+
+**Propuesta si se necesita:**
+```sql
+CREATE TABLE cooperative_members (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  cooperative_id uuid NOT NULL REFERENCES cooperatives(id),
+  prosumer_id uuid NOT NULL REFERENCES prosumers(id),
+  role text DEFAULT 'prosumer' CHECK (role = ANY (ARRAY['prosumer','copropietario','mixed'])),
+  joined_at timestamptz DEFAULT now(),
+  is_active boolean DEFAULT true,
+  UNIQUE(cooperative_id, prosumer_id)
+);
+```
+
+---
+
+### ⚠️ Paso 4 — Registrar medidores
+**Tabla:** `meters`  
+**Endpoint:** `POST /api/meters`
+
+**Gaps identificados:**
+
+1. `member_stellar_address` es texto libre sin FK a `prosumers.stellar_address` — puede registrarse un medidor para una wallet que no existe en el sistema.
+
+2. `serial_number` sin UNIQUE — ya documentado en el análisis del ERD. Riesgo de doble conteo.
+
+**Impacto en UX/UI:**  
+Si el campo de dirección Stellar acepta cualquier valor sin validación a nivel de DB, la UI puede mostrar medidores "huérfanos" sin dueño real.
+
+---
+
+### ⚠️ Paso 5 — Cargar lecturas
+**Tabla:** `readings`  
+**Endpoints:** `POST /api/readings`, `POST /api/meters/readings`
+
+**Gap identificado:**  
+`kwh_injected` es NOT NULL pero el flujo dice que lo importante es `kwh_generated`. Un medidor que solo registra generación (sin inyección a red) igual tiene que enviar un valor para `kwh_injected` aunque no lo tenga.
+
+**Impacto en UX/UI:**  
+El formulario de "Registrar Lectura" debería reflejar qué campos son realmente obligatorios. Hoy puede generar confusión porque el campo existe pero no siempre tiene datos reales.
+
+---
+
+## Resumen de gaps
+
+| Paso | Gap | Tipo | Decisión requerida |
+|---|---|---|---|
+| Registrar cooperativa | `admin_stellar_address` sin FK | Diseño | ¿El admin es siempre un prosumidor? |
+| Agregar miembros | Un prosumidor = una cooperativa | Diseño | ¿Membresías múltiples? |
+| Registrar medidores | `member_stellar_address` sin FK | Integridad | Sí — agregar FK |
+| Registrar medidores | `serial_number` sin UNIQUE | Integridad | Sí — agregar UNIQUE |
+| Cargar lecturas | `kwh_injected` NOT NULL | Lógica | Sí — hacer nullable |
+
+---
+
+## Decisiones que necesito de el equipo
+
+1. **¿El admin de una cooperativa tiene que ser un prosumidor registrado?**  
+   Si sí → agregar FK `cooperatives.admin_stellar_address → prosumers.stellar_address`  
+   Si no → documentar que son entidades separadas
+
+2. **¿Un prosumidor puede pertenecer a más de una cooperativa?**  
+   Si sí → necesitamos tabla `cooperative_members` (many-to-many)  
+   Si no → el modelo actual es correcto, solo documentarlo
+
+Estas dos decisiones afectan directamente el diseño de las pantallas de UX/UI — por eso necesito resolverlas antes de avanzar con los wireframes.

--- a/docs/next-steps/feedback-landing-beenergy.md
+++ b/docs/next-steps/feedback-landing-beenergy.md
@@ -1,0 +1,73 @@
+# Feedback Landing Page — BeEnergy
+
+Hola! Estamos trabajando en mejorar la landing page de BeEnergy y queremos que quede lo mejor posible antes de la próxima demo.
+
+Para poder hacer cambios concretos y no perder tiempo en suposiciones, necesitamos tu ayuda respondiendo estas preguntas. No hay respuestas correctas o incorrectas — lo que importa es tu perspectiva honesta.
+
+---
+
+## 1. Primera impresión
+Cuando entrás a https://be-energy-six.vercel.app, ¿qué entendés que hace el producto en los primeros 5 segundos?
+
+**Tu respuesta:**
+
+
+---
+
+## 2. ¿A quién le habla?
+¿Sentís que la página está dirigida a vos? ¿O a otro tipo de usuario?
+
+- [ ] Sí, me habla a mí directamente
+- [ ] Más o menos, pero falta algo
+- [ ] No, no me siento identificado/a
+
+**¿Por qué?**
+
+
+---
+
+## 3. El mensaje principal
+El headline actual dice: *"Tu compromiso ambiental, verificable en blockchain."*
+
+¿Te parece claro? ¿Cambiarías algo?
+
+**Tu respuesta:**
+
+
+---
+
+## 4. Lo que falta
+¿Hay algo importante sobre BeEnergy que NO está explicado en la página y debería estar?
+
+**Tu respuesta:**
+
+
+---
+
+## 5. Lo que sobra o confunde
+¿Hay algo en la página que te resulte confuso, innecesario o que quitarías?
+
+**Tu respuesta:**
+
+
+---
+
+## 6. El botón principal
+El botón dice: *"Acceder a la plataforma"*
+
+¿Te genera ganas de hacer click? ¿Qué dirías vos que debería decir?
+
+**Tu respuesta:**
+
+
+---
+
+## 7. Prioridad
+Si pudieras cambiar UNA sola cosa de la landing ahora mismo, ¿qué sería?
+
+**Tu respuesta:**
+
+
+---
+
+Gracias por tu tiempo! Con esto podemos hacer cambios reales y concretos. 

--- a/docs/next-steps/mejoras-modelo-relacional-beenergy.md
+++ b/docs/next-steps/mejoras-modelo-relacional-beenergy.md
@@ -1,0 +1,261 @@
+# BeEnergy — Mejoras al Modelo Relacional
+**Fecha:** Mayo 2026  
+**Preparado por:** romina-iurchik  
+**Para:** el equipo (Tech Lead)  
+**Contexto:** Análisis del schema actual vs flujos documentados en `/docs`
+
+---
+
+## Resumen ejecutivo
+
+Revisando el schema de Supabase contra los flujos de usuario documentados encontré **3 problemas críticos de integridad de datos**, **4 issues de performance y trazabilidad**, y **3 mejoras para soportar el flujo del comprador ESG** que hoy no tiene tabla propia.
+
+---
+
+## 🔴 Críticos — afectan integridad de datos
+
+### 1. `serial_number` sin UNIQUE en `meters`
+Sin este constraint, dos medidores pueden tener el mismo número de serie — doble conteo garantizado. Es el mismo riesgo de double counting que documentamos en el PR #149 pero a nivel de hardware.
+
+```sql
+ALTER TABLE meters 
+ADD CONSTRAINT meters_serial_number_unique UNIQUE (serial_number);
+```
+
+---
+
+### 2. `certificates.status` incluye valor `'sold'` que no existe en el flujo
+El check constraint permite `'sold'` pero en el código y los flujos documentados el ciclo de vida es `pending → available → retired`. El estado `'sold'` nunca se usa y puede generar inconsistencias si alguien lo setea accidentalmente.
+
+```sql
+ALTER TABLE certificates DROP CONSTRAINT certificates_status_check;
+ALTER TABLE certificates ADD CONSTRAINT certificates_status_check 
+  CHECK (status = ANY (ARRAY['pending'::text, 'available'::text, 'retired'::text]));
+```
+
+---
+
+### 3. `readings.kwh_injected` es NOT NULL pero `kwh_generated` tiene DEFAULT 0
+El flujo real dice que lo importante es `kwh_generated` (lo que produce el panel). Pero `kwh_injected` (lo que se inyecta a la red) es NOT NULL — si un medidor registra solo generación sin inyectar a la red, igual tiene que mandar un valor aunque sea 0.
+
+**Propuesta:** Hacer `kwh_injected` nullable y documentar cuál campo es el canónico para certificación.
+
+```sql
+ALTER TABLE readings ALTER COLUMN kwh_injected DROP NOT NULL;
+```
+
+---
+
+## 🟡 Importantes — performance y trazabilidad
+
+### 4. Faltan índices en las queries más frecuentes
+Las queries más usadas en el dashboard son por `cooperative_id + status` y por `meter_id + reading_date`. Sin índices estas queries escanean toda la tabla — va a ser un problema cuando haya cooperativas reales con miles de lecturas.
+
+```sql
+CREATE INDEX idx_readings_cooperative_status 
+  ON readings(cooperative_id, status);
+
+CREATE INDEX idx_readings_meter_date 
+  ON readings(meter_id, reading_date DESC);
+
+CREATE INDEX idx_certificates_cooperative_status 
+  ON certificates(cooperative_id, status);
+
+CREATE INDEX idx_mint_log_certificate 
+  ON mint_log(certificate_id);
+```
+
+---
+
+### 5. `stellar_address` sin FK en `meters` y `events`
+- `meters.member_stellar_address` es texto libre sin referencia a `prosumers.stellar_address`
+- `events.stellar_address` es texto libre sin referencia a nada
+
+Esto significa que puede haber lecturas de medidores asignados a wallets que no existen en la tabla de prosumers, y eventos huérfanos sin trazabilidad.
+
+```sql
+-- Primero limpiar datos huérfanos si los hay, luego:
+ALTER TABLE meters 
+ADD CONSTRAINT meters_member_stellar_address_fkey 
+  FOREIGN KEY (member_stellar_address) REFERENCES prosumers(stellar_address);
+```
+
+---
+
+### 6. `prosumers` sin campo `is_active`
+No hay forma de desactivar un miembro sin borrarlo. Si un prosumidor sale de la cooperativa, hoy la única opción es eliminarlo — perdiendo el historial de lecturas y certificados asociados.
+
+```sql
+ALTER TABLE prosumers 
+ADD COLUMN is_active boolean NOT NULL DEFAULT true;
+
+CREATE INDEX idx_prosumers_cooperative_active 
+  ON prosumers(cooperative_id, is_active);
+```
+
+---
+
+### 7. `mint_log` sin constraint que asegure referencia válida
+`mint_log` tiene `reading_id` y `certificate_id` pero ninguno es obligatorio. Debería haber al menos uno presente para que el registro tenga sentido.
+
+```sql
+ALTER TABLE mint_log 
+ADD CONSTRAINT mint_log_requires_reading_or_cert 
+  CHECK (reading_id IS NOT NULL OR certificate_id IS NOT NULL);
+```
+
+---
+
+## 🟢 Mejoras — para soportar el flujo del comprador ESG
+
+### 8. Falta tabla `companies` para compradores externos
+El flujo del comprador ESG (el cliente que paga) no tiene tabla propia. Hoy `retirements.buyer_name` y `buyer_address` son texto libre — no hay trazabilidad real de quién compró qué.
+
+Para el modelo B2B que queremos, necesitamos poder ver el historial de compras por empresa.
+
+```sql
+CREATE TABLE companies (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  stellar_address text UNIQUE,
+  country_code text DEFAULT 'AR',
+  tax_id text,
+  contact_email text,
+  created_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE retirements 
+ADD COLUMN company_id uuid REFERENCES companies(id);
+```
+
+---
+
+### 9. `cooperatives.country` debería ser código ISO
+Hoy `country DEFAULT 'AR'` es texto libre. Si queremos escalar a otros países conviene usar el estándar ISO 3166-1 alpha-2 (AR, CL, MX, etc.) con un check constraint.
+
+```sql
+ALTER TABLE cooperatives 
+ADD CONSTRAINT cooperatives_country_format 
+  CHECK (country ~ '^[A-Z]{2}$');
+```
+
+---
+
+## Script de migración completo (para revisar antes de ejecutar)
+
+```sql
+-- ============================================
+-- BeEnergy — Migration Wave #5
+-- Revisar con el equipo antes de ejecutar en prod
+-- ============================================
+
+-- 1. UNIQUE serial_number en meters
+ALTER TABLE meters 
+ADD CONSTRAINT meters_serial_number_unique UNIQUE (serial_number);
+
+-- 2. Limpiar status 'sold' de certificates
+ALTER TABLE certificates DROP CONSTRAINT IF EXISTS certificates_status_check;
+ALTER TABLE certificates ADD CONSTRAINT certificates_status_check 
+  CHECK (status = ANY (ARRAY['pending'::text, 'available'::text, 'retired'::text]));
+
+-- 3. kwh_injected nullable
+ALTER TABLE readings ALTER COLUMN kwh_injected DROP NOT NULL;
+
+-- 4. Índices de performance
+CREATE INDEX IF NOT EXISTS idx_readings_cooperative_status 
+  ON readings(cooperative_id, status);
+CREATE INDEX IF NOT EXISTS idx_readings_meter_date 
+  ON readings(meter_id, reading_date DESC);
+CREATE INDEX IF NOT EXISTS idx_certificates_cooperative_status 
+  ON certificates(cooperative_id, status);
+CREATE INDEX IF NOT EXISTS idx_mint_log_certificate 
+  ON mint_log(certificate_id);
+
+-- 5. is_active en prosumers
+ALTER TABLE prosumers 
+ADD COLUMN IF NOT EXISTS is_active boolean NOT NULL DEFAULT true;
+CREATE INDEX IF NOT EXISTS idx_prosumers_cooperative_active 
+  ON prosumers(cooperative_id, is_active);
+
+-- 6. CHECK en mint_log
+ALTER TABLE mint_log 
+ADD CONSTRAINT mint_log_requires_reading_or_cert 
+  CHECK (reading_id IS NOT NULL OR certificate_id IS NOT NULL);
+
+-- 7. Tabla companies
+CREATE TABLE IF NOT EXISTS companies (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  stellar_address text UNIQUE,
+  country_code text DEFAULT 'AR',
+  tax_id text,
+  contact_email text,
+  created_at timestamptz DEFAULT now()
+);
+ALTER TABLE retirements 
+ADD COLUMN IF NOT EXISTS company_id uuid REFERENCES companies(id);
+
+-- 8. Country format check
+ALTER TABLE cooperatives 
+ADD CONSTRAINT IF NOT EXISTS cooperatives_country_format 
+  CHECK (country ~ '^[A-Z]{2}$');
+```
+
+---
+
+## Priorización sugerida
+
+| # | Cambio | Impacto | Riesgo de migración |
+|---|---|---|---|
+| 1 | UNIQUE serial_number | 🔴 Crítico | Bajo — puede fallar si hay duplicados existentes |
+| 2 | Limpiar status 'sold' | 🔴 Crítico | Bajo — verificar que no haya rows con 'sold' |
+| 3 | kwh_injected nullable | 🔴 Crítico | Bajo |
+| 4 | Índices de performance | 🟡 Alto | Ninguno — solo agregan |
+| 5 | is_active en prosumers | 🟡 Alto | Bajo |
+| 6 | CHECK mint_log | 🟡 Alto | Medio — puede fallar si hay rows sin reading_id ni certificate_id |
+| 7 | Tabla companies | 🟢 Medio | Ninguno — tabla nueva |
+| 8 | Country format check | 🟢 Medio | Medio — verificar datos existentes |
+
+---
+
+## Notas importantes antes de ejecutar
+
+1. **Verificar duplicados** en `meters.serial_number` antes del constraint UNIQUE:
+```sql
+SELECT serial_number, COUNT(*) 
+FROM meters 
+WHERE serial_number IS NOT NULL 
+GROUP BY serial_number 
+HAVING COUNT(*) > 1;
+```
+
+2. **Verificar status 'sold'** antes de limpiar el constraint:
+```sql
+SELECT COUNT(*) FROM certificates WHERE status = 'sold';
+```
+
+3. **Verificar mint_log** antes del CHECK:
+```sql
+SELECT COUNT(*) FROM mint_log 
+WHERE reading_id IS NULL AND certificate_id IS NULL;
+```
+
+4. **Verificar country format** antes del CHECK:
+```sql
+SELECT DISTINCT country FROM cooperatives;
+```
+
+---
+
+## Verificaciones realizadas — Mayo 2026 ✅
+
+Antes de ejecutar la migración se corrieron las siguientes verificaciones en Supabase SQL Editor. Todos los resultados son seguros para proceder.
+
+| # | Verificación | Resultado | Estado |
+|---|---|---|---|
+| 1 | Duplicados en serial_number | Sin filas | ✅ OK |
+| 2 | Certificados con status 'sold' | 0 | ✅ OK |
+| 3 | mint_log sin referencias | 0 | ✅ OK |
+| 4 | Valores de country | Solo 'AR' | ✅ OK |
+
+**La migración puede ejecutarse sin riesgo. Proceder con el script de migración completo.**

--- a/docs/next-steps/qa-report
+++ b/docs/next-steps/qa-report
@@ -1,0 +1,210 @@
+# QA Report — BeEnergy v0.4.2 (Wave #5)
+
+**Fecha última actualización:** Junio 2026  
+**Testeado por:** romina-iurchik  
+**Rama:** `main` (develop mergeado)  
+**Red:** Stellar Testnet  
+
+---
+
+## Resumen ejecutivo
+
+| | Cantidad |
+|---|---|
+| ✅ Funcionalidades verificadas | 30 |
+| ✅ Bugs resueltos Wave #5 | 19 |
+| 🐛 Bugs pendientes | 8 |
+| ⚠️ Issues de UX | 5 |
+| 🗄️ Issues de base de datos | 3 |
+| 📋 Observaciones | 4 |
+
+---
+
+## Mapa de rutas testeadas
+
+```
+/                         → Landing page
+/dashboard                → Dashboard miembro (personal)
+/consumption              → Historial de generación
+/certificates             → Certificados de energía
+/dashboard/cooperative    → Panel admin cooperativa
+/dashboard/admin          → Panel super admin (BeEnergy)
+```
+
+---
+
+## ✅ Bugs resueltos (romina-iurchik)
+
+| # | Descripción | Commit |
+|---|---|---|
+| BUG-01 | Abeja flotante desactivada | 42e30de |
+| BUG-02 | Tachado en onboarding removido | baff304 |
+| BUG-03 | Campos País/Provincia/Ciudad en cooperativa | 1243a27 |
+| BUG-04 | Logo abeja en sidebar y mobile sidebar | e297db7 |
+| BUG-05 | Logo navega al dashboard con Link | 6097645 |
+| BUG-06 | Fechas futuras bloqueadas en lecturas | 6097645 |
+| BUG-07 | Error "No verified readings" traducido + hint | d8bf4cb |
+| BUG-08 | Error "Validation failed" con mensaje claro | d8bf4cb |
+| BUG-09 | Número de serie obligatorio en medidor | d8bf4cb |
+| BUG-10 | Campo Potencia ocultado en lecturas | d8bf4cb |
+| BUG-11 | Fix timeout mint y retire (txTooLate) | bacc69e |
+| BUG-12 | Generación Total muestra certificados vs por certificar | - |
+| BUG-13 | Onboarding colapsable con chevron | 607f44f |
+| BUG-14 | Hero landing con foco en empresa ESG | - |
+| BUG-15 | Math.max(0) para evitar kWh negativos | - |
+
+## ✅ Bugs resueltos (contributors Wave #5)
+
+| # | Descripción | Contributor | PR |
+|---|---|---|---|
+| BUG-W5-01 | Stat card "Pendientes" como filtro en `/certificates` | licette32 | #164 |
+| BUG-W5-04 | Feedback de éxito en modal "Agregar Medidor" | KaruG1999 | #162 |
+| BUG-W5-06 | Columna Miembros vacía en tabla admin | KaruG1999 | #163 |
+| BUG-W5-12 | Tests fallando (.order() y .single() mocks) | licette32 | #165 |
+
+---
+
+## 🐛 Bugs pendientes
+
+### BUG-W5-02 — Fecha inválida en certificado existente
+**Ruta:** `/certificates`  
+**Severidad:** Baja (dato sucio pre-fix)  
+**Descripción:** Certificado muestra `Período: 9 mar 2028 — 19 mar 2026` — fecha de inicio posterior a fecha de fin.  
+**Fix sugerido:** Limpiar dato en Supabase.
+
+---
+
+### BUG-W5-03 — Datos de IntTest Coop visibles
+**Ruta:** `/certificates`, `/dashboard/admin`  
+**Severidad:** Media  
+**Descripción:** Múltiples cooperativas `IntTest Coop 177...` visibles — son datos de tests de integración.  
+**Fix sugerido:** Cleanup en Supabase.
+
+---
+
+### BUG-W5-05 — "Ver miembros →" no navega
+**Ruta:** `/dashboard/cooperative`  
+**Severidad:** Media  
+**Descripción:** El link "Ver miembros →" no hace nada al hacer click. La ruta `/dashboard/cooperative/members` no está implementada.
+
+---
+
+### BUG-W5-07 — `SUPER_ADMIN_ADDRESSES` no documentado
+**Ruta:** `.env`, README  
+**Severidad:** Media  
+**Descripción:** Variable de entorno no documentada en `.env.example` ni en README.  
+**Fix sugerido:** Documentar en ambos archivos.
+
+---
+
+### BUG-W5-08 — Hydration mismatch en DashboardHeader
+**Ruta:** Todas las rutas con `DashboardHeader`  
+**Severidad:** Baja  
+**Descripción:** IDs de Radix UI no coinciden entre SSR y cliente. Warning en consola, no afecta funcionalidad.
+
+---
+
+### BUG-W5-09 — Double counting risk (sin fix)
+**Ruta:** `/api/mint`, `/api/certificates`  
+**Severidad:** Alta  
+**Descripción:** El mint legacy usa generación bruta, `kwh_self_consumed` no se usa para restringir certificación.  
+**Fix sugerido:** Wave #5-A (validar kwh_self_consumed) + Wave #5-B (provenance de lecturas).
+
+---
+
+### BUG-W5-10 — Actividad Reciente no carga en Vercel
+**Ruta:** `/activity`  
+**Severidad:** Media  
+**Descripción:** "No se pudo cargar el historial de pagos" en producción. Posible problema de CSP o CORS con Horizon.
+
+---
+
+### BUG-W5-11 — Retire falla en Vercel
+**Ruta:** `/certificates` → Retirar Certificado  
+**Severidad:** Alta  
+**Descripción:** "Internal server error" al intentar retirar certificado en Vercel.
+
+---
+
+## ⚠️ Issues de UX
+
+### UX-02 — Campo Capacidad sin hint de unidad
+"Capacidad (kW)" en Agregar Medidor no tiene validación de rango. Fácil confundir W con kW.
+
+### UX-03 — Dashboard miembro no diferencia por rol
+El `/dashboard` muestra la misma vista para miembro y admin. (Issue #012)
+
+### UX-04 — Gráfico de Generación muestra 0 kWh
+El gráfico muestra la semana actual pero las lecturas verificadas son de meses anteriores. Sin indicación clara de período sin datos.
+
+### UX-05 — "Dashboard" en inglés en sidebar
+La palabra "Dashboard" debería ser "Panel" o "Inicio" en español.
+
+### UX-06 — "Testnet" no comprensible para usuarios no técnicos
+Debería decir "Modo de prueba" o "Simulación".
+
+---
+
+## 🗄️ Issues de base de datos
+
+### DB-01 — `stellar_address` sin FK en events, meters y cooperatives
+**Severidad:** Media  
+**Fix sugerido:** Agregar FK o validación a nivel de API.
+
+### DB-02 — `serial_number` en meters sin constraint UNIQUE
+**Severidad:** Alta  
+**Fix sugerido:**
+```sql
+ALTER TABLE meters ADD CONSTRAINT meters_serial_number_unique UNIQUE (serial_number);
+```
+
+### DB-03 — Tablas de soporte sin documentar
+**Severidad:** Baja  
+- `audit_log` — trazabilidad de cambios
+- `rate_limits` — prevención de abuso de API
+- `auth_challenges` — flujo SEP-0053 (Freighter auth)
+
+---
+
+## 📋 Observaciones generales
+
+1. **Datos de prueba en producción** — Datos de cooperativas simuladas visibles en panel admin.
+2. **`SUPER_ADMIN_ADDRESSES`** — variable de entorno no documentada.
+3. **Workaround timeout** — `.setTimeout(250)` en `/api/mint` y `/api/certificates/retire`. Pendiente reemplazar por timeout dinámico basado en ledger.
+4. **Landing page** — Hero actualizado con foco en empresa ESG. Secciones "Qué hacemos" y "Cómo funciona" pendientes.
+5. **Performance — member count** — El PR #163 filtra prosumers en memoria. Cuando la plataforma escale conviene reemplazar por query SQL con `GROUP BY cooperative_id`.
+
+---
+
+## Pendientes
+
+### Bugs críticos
+- [ ] BUG-W5-09 — Fix double counting (Wave #5-A + Wave #5-B)
+- [ ] BUG-W5-11 — Verificar fix retire en Vercel
+- [ ] BUG-W5-10 — Fix Actividad Reciente en Vercel
+
+### Bugs medios
+- [ ] BUG-W5-05 — Implementar `/dashboard/cooperative/members`
+- [ ] BUG-W5-07 — Documentar `SUPER_ADMIN_ADDRESSES`
+- [ ] BUG-W5-03 — Cleanup datos IntTest Coop en Supabase
+
+### Base de datos
+- [ ] DB-01 — Agregar FK para `stellar_address`
+- [ ] DB-02 — Agregar constraint UNIQUE en `serial_number`
+- [ ] DB-03 — Documentar tablas de soporte en README
+
+### UX
+- [ ] UX-05 — "Dashboard" → "Panel"
+- [ ] UX-06 — "Testnet" → "Modo de prueba"
+
+### Landing
+- [ ] Actualizar sección "Qué hacemos" con foco empresa ESG
+- [ ] Actualizar sección "Cómo funciona" con foco empresa ESG
+- [ ] Agregar sección de diferenciadores vs mercado actual
+
+### Features próxima wave
+- [ ] Selector dinámico Provincia/Ciudad por País
+- [ ] Scope `/certificates` por rol (issue #012)
+- [ ] Vista empresa ESG — tabla `companies`
+- [ ] Implementar `/dashboard/cooperative/members`
+- [ ] Video de onboarding


### PR DESCRIPTION
## Description

The existing `lib/rate-limit.ts` was not wired into any route. This PR applies it to the two auth endpoints that are exposed to public traffic and vulnerable to brute force/enumeration attacks.

## Related Issue

Closes #179

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test addition/update

## Changes Made

- Applied IP-based rate limiting (10 req/min) to `POST /api/auth/challenge` via `checkRateLimit` + `getClientIp`
- Applied IP-based rate limiting (5 req/min) to `POST /api/auth/verify`
- Applied per-wallet rate limiting (5 req/min) to `POST /api/auth/verify` after the body is parsed and the address is validated
- Both return `429 Too Many Requests` with a `Retry-After` header when the limit is exceeded (behaviour already implemented in `lib/rate-limit.ts`)
- Added `__tests__/api/auth-challenge.test.ts` covering 429, Retry-After, and no false positives
- Added `__tests__/api/auth-verify.test.ts` covering IP limit exceeded, per-wallet limit exceeded, no false positives, and missing fields

## Checklist

- [x] My code follows the project's style guidelines (run `pnpm format`)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (57/57)

## Testing Instructions

1. Checkout this branch: `git checkout fix/179-rate-limit-auth-endpoints`
2. Install dependencies: `pnpm install`
3. Run tests: `cd apps/web && pnpm test:api`
4. Verify all 57 tests pass, including the 7 new auth rate-limit tests

## For Bounty Issues

- [x] I have linked the bounty issue this PR resolves
- [x] All acceptance criteria from the issue are met
- [ ] I have tested on testnet with Freighter wallet (if applicable)
- [x] I have provided my Stellar address for bounty payout: `GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37`