### PR TITLE
fix(web): apply rate limiting to auth endpoints

### DIFF
--- a/apps/web/__tests__/api/auth-challenge.test.ts
+++ b/apps/web/__tests__/api/auth-challenge.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const ADDR = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+const { mockRpc, mockCheckRateLimit } = vi.hoisted(() => {
+  const mockRpc = vi.fn();
+  const mockCheckRateLimit = vi.fn(async () => null);
+  return { mockRpc, mockCheckRateLimit };
+});
+
+const { mockFrom, mockSingle } = vi.hoisted(() => {
+  const mockSingle = vi.fn();
+  const mockEq: ReturnType<typeof vi.fn> = vi.fn(() => ({
+    single: mockSingle,
+    eq: mockEq,
+  }));
+  const mockDelete = vi.fn(() => ({ lt: vi.fn(() => ({})) }));
+  const mockInsert = vi.fn(() => ({ error: null }));
+  const mockFrom = vi.fn(() => ({
+    delete: mockDelete,
+    insert: mockInsert,
+    select: vi.fn(() => ({ eq: mockEq })),
+  }));
+  return { mockFrom, mockSingle };
+});
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: { from: mockFrom, rpc: mockRpc },
+}));
+
+vi.mock("@/lib/auth/stellar-verify", () => ({
+  isValidStellarAddress: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: mockCheckRateLimit,
+  getClientIp: vi.fn(() => "127.0.0.1"),
+}));
+
+import { POST } from "@/app/api/auth/challenge/route";
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/auth/challenge", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/auth/challenge", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 400 when stellar_address is missing", async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 429 with Retry-After when IP rate limit is exceeded", async () => {
+    const { NextResponse } = await import("next/server");
+    mockCheckRateLimit.mockResolvedValueOnce(
+      NextResponse.json(
+        { error: "Too many requests" },
+        {
+          status: 429,
+          headers: { "Retry-After": "60" },
+        },
+      ),
+    );
+
+    const res = await POST(makeRequest({ stellar_address: ADDR }));
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("60");
+  });
+
+  it("returns 200 for a single request under the limit (no false positives)", async () => {
+    mockCheckRateLimit.mockResolvedValueOnce(null);
+    mockFrom.mockReturnValueOnce({
+      delete: vi.fn(() => ({ lt: vi.fn(() => ({})) })),
+    });
+    mockFrom.mockReturnValueOnce({ insert: vi.fn(() => ({ error: null })) });
+
+    const res = await POST(makeRequest({ stellar_address: ADDR }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toHaveProperty("challenge");
+  });
+});

--- a/apps/web/__tests__/api/auth-verify.test.ts
+++ b/apps/web/__tests__/api/auth-verify.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const ADDR = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const CHALLENGE = "abc123";
+const SIG = "sig";
+
+const { mockCheckRateLimit } = vi.hoisted(() => {
+  const mockCheckRateLimit = vi.fn(async () => null);
+  return { mockCheckRateLimit };
+});
+
+const { mockFrom, mockSingle } = vi.hoisted(() => {
+  const mockSingle = vi.fn();
+  const mockEq: ReturnType<typeof vi.fn> = vi.fn(() => ({
+    single: mockSingle,
+    eq: mockEq,
+  }));
+  const mockDelete = vi.fn(() => ({ eq: vi.fn(() => ({})) }));
+  const mockFrom = vi.fn(() => ({
+    select: vi.fn(() => ({ eq: mockEq })),
+    delete: mockDelete,
+  }));
+  return { mockFrom, mockSingle };
+});
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: { from: mockFrom },
+}));
+
+vi.mock("@/lib/auth/stellar-verify", () => ({
+  isValidStellarAddress: vi.fn(() => true),
+  verifySignature: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/auth/roles", () => ({
+  resolveRoles: vi.fn(async () => ({
+    cooperative_ids: [],
+    admin_cooperative_ids: [],
+  })),
+}));
+
+vi.mock("@/lib/auth/jwt", () => ({
+  signJWT: vi.fn(async () => "token"),
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  setSessionCookie: vi.fn((res) => res),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: mockCheckRateLimit,
+  getClientIp: vi.fn(() => "127.0.0.1"),
+}));
+
+import { POST } from "@/app/api/auth/verify/route";
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/auth/verify", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  stellar_address: ADDR,
+  challenge: CHALLENGE,
+  signature: SIG,
+};
+
+describe("POST /api/auth/verify", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 429 with Retry-After when IP rate limit is exceeded", async () => {
+    const { NextResponse } = await import("next/server");
+    mockCheckRateLimit.mockResolvedValueOnce(
+      NextResponse.json(
+        { error: "Too many requests" },
+        {
+          status: 429,
+          headers: { "Retry-After": "60" },
+        },
+      ),
+    );
+
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("60");
+  });
+
+  it("returns 429 with Retry-After when per-wallet rate limit is exceeded", async () => {
+    const { NextResponse } = await import("next/server");
+    // IP check passes, wallet check fails
+    mockCheckRateLimit.mockResolvedValueOnce(null).mockResolvedValueOnce(
+      NextResponse.json(
+        { error: "Too many requests" },
+        {
+          status: 429,
+          headers: { "Retry-After": "60" },
+        },
+      ),
+    );
+
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("60");
+  });
+
+  it("returns 200 for a single request under the limit (no false positives)", async () => {
+    mockCheckRateLimit.mockResolvedValue(null);
+    mockSingle.mockResolvedValueOnce({
+      data: {
+        id: "id-1",
+        stellar_address: ADDR,
+        challenge: CHALLENGE,
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+      },
+      error: null,
+    });
+
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 400 when required fields are missing", async () => {
+    mockCheckRateLimit.mockResolvedValue(null);
+    const res = await POST(makeRequest({ stellar_address: ADDR }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/app/api/auth/challenge/route.ts
+++ b/apps/web/app/api/auth/challenge/route.ts
@@ -1,43 +1,51 @@
-import { NextRequest, NextResponse } from "next/server"
-import { randomBytes } from "crypto"
-import { supabase } from "@/lib/supabase"
-import { isValidStellarAddress } from "@/lib/auth/stellar-verify"
+import { NextRequest, NextResponse } from "next/server";
+import { randomBytes } from "crypto";
+import { supabase } from "@/lib/supabase";
+import { isValidStellarAddress } from "@/lib/auth/stellar-verify";
+import { checkRateLimit, getClientIp } from "@/lib/rate-limit";
 
 export async function POST(req: NextRequest) {
+  const ip = getClientIp(req);
+  const rateLimitResponse = await checkRateLimit(ip, "auth/challenge");
+  if (rateLimitResponse) return rateLimitResponse;
+
   try {
-    const body = await req.json()
-    const { stellar_address } = body
+    const body = await req.json();
+    const { stellar_address } = body;
 
     if (!stellar_address || !isValidStellarAddress(stellar_address)) {
       return NextResponse.json(
         { error: "Valid stellar_address required" },
-        { status: 400 }
-      )
+        { status: 400 },
+      );
     }
 
     // Generate random challenge
-    const challenge = randomBytes(32).toString("hex")
-    const expires_at = new Date(Date.now() + 5 * 60 * 1000).toISOString() // 5 min TTL
+    const challenge = randomBytes(32).toString("hex");
+    const expires_at = new Date(Date.now() + 5 * 60 * 1000).toISOString(); // 5 min TTL
 
     // Clean expired challenges first
     await supabase
       .from("auth_challenges")
       .delete()
-      .lt("expires_at", new Date().toISOString())
+      .lt("expires_at", new Date().toISOString());
 
     // Store challenge
     const { error } = await supabase.from("auth_challenges").insert({
       stellar_address,
       challenge,
       expires_at,
-    })
+    });
 
     if (error) {
-      return NextResponse.json({ error: "Failed to create challenge" }, { status: 500 })
+      return NextResponse.json(
+        { error: "Failed to create challenge" },
+        { status: 500 },
+      );
     }
 
-    return NextResponse.json({ challenge })
+    return NextResponse.json({ challenge });
   } catch {
-    return NextResponse.json({ error: "Invalid request" }, { status: 400 })
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
   }
 }

--- a/apps/web/app/api/auth/verify/route.ts
+++ b/apps/web/app/api/auth/verify/route.ts
@@ -1,25 +1,43 @@
-import { NextRequest, NextResponse } from "next/server"
-import { supabase } from "@/lib/supabase"
-import { isValidStellarAddress, verifySignature } from "@/lib/auth/stellar-verify"
-import { resolveRoles } from "@/lib/auth/roles"
-import { signJWT } from "@/lib/auth/jwt"
-import { setSessionCookie } from "@/lib/auth/session"
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import {
+  isValidStellarAddress,
+  verifySignature,
+} from "@/lib/auth/stellar-verify";
+import { resolveRoles } from "@/lib/auth/roles";
+import { signJWT } from "@/lib/auth/jwt";
+import { setSessionCookie } from "@/lib/auth/session";
+import { checkRateLimit, getClientIp } from "@/lib/rate-limit";
 
 export async function POST(req: NextRequest) {
+  const ip = getClientIp(req);
+  const ipLimit = await checkRateLimit(ip, "auth/verify");
+  if (ipLimit) return ipLimit;
+
   try {
-    const body = await req.json()
-    const { stellar_address, challenge, signature } = body
+    const body = await req.json();
+    const { stellar_address, challenge, signature } = body;
 
     if (!stellar_address || !challenge || !signature) {
       return NextResponse.json(
-        { error: "Missing required fields: stellar_address, challenge, signature" },
-        { status: 400 }
-      )
+        {
+          error:
+            "Missing required fields: stellar_address, challenge, signature",
+        },
+        { status: 400 },
+      );
     }
 
     if (!isValidStellarAddress(stellar_address)) {
-      return NextResponse.json({ error: "Invalid stellar_address" }, { status: 400 })
+      return NextResponse.json(
+        { error: "Invalid stellar_address" },
+        { status: 400 },
+      );
     }
+
+    // Per-wallet rate limit (5 attempts per minute per address)
+    const walletLimit = await checkRateLimit(stellar_address, "auth/verify");
+    if (walletLimit) return walletLimit;
 
     // Lookup challenge
     const { data: stored, error: lookupError } = await supabase
@@ -27,35 +45,38 @@ export async function POST(req: NextRequest) {
       .select("*")
       .eq("challenge", challenge)
       .eq("stellar_address", stellar_address)
-      .single()
+      .single();
 
     if (lookupError || !stored) {
-      return NextResponse.json({ error: "Invalid or expired challenge" }, { status: 401 })
+      return NextResponse.json(
+        { error: "Invalid or expired challenge" },
+        { status: 401 },
+      );
     }
 
     // Check expiry
     if (new Date(stored.expires_at) < new Date()) {
-      await supabase.from("auth_challenges").delete().eq("id", stored.id)
-      return NextResponse.json({ error: "Challenge expired" }, { status: 401 })
+      await supabase.from("auth_challenges").delete().eq("id", stored.id);
+      return NextResponse.json({ error: "Challenge expired" }, { status: 401 });
     }
 
     // Verify signature
     if (!verifySignature(stellar_address, challenge, signature)) {
-      return NextResponse.json({ error: "Invalid signature" }, { status: 401 })
+      return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
     }
 
     // Delete used challenge
-    await supabase.from("auth_challenges").delete().eq("id", stored.id)
+    await supabase.from("auth_challenges").delete().eq("id", stored.id);
 
     // Resolve roles
-    const roles = await resolveRoles(stellar_address)
+    const roles = await resolveRoles(stellar_address);
 
     // Check super admin
     const superAdminAddresses = (process.env.SUPER_ADMIN_ADDRESSES || "")
       .split(",")
       .map((a) => a.trim())
-      .filter(Boolean)
-    const is_super_admin = superAdminAddresses.includes(stellar_address)
+      .filter(Boolean);
+    const is_super_admin = superAdminAddresses.includes(stellar_address);
 
     // Sign JWT
     const token = await signJWT({
@@ -63,7 +84,7 @@ export async function POST(req: NextRequest) {
       cooperative_ids: roles.cooperative_ids,
       admin_cooperative_ids: roles.admin_cooperative_ids,
       is_super_admin,
-    })
+    });
 
     // Set cookie and return session info
     const response = NextResponse.json({
@@ -71,10 +92,10 @@ export async function POST(req: NextRequest) {
       cooperative_ids: roles.cooperative_ids,
       admin_cooperative_ids: roles.admin_cooperative_ids,
       is_super_admin,
-    })
+    });
 
-    return setSessionCookie(response, token)
+    return setSessionCookie(response, token);
   } catch {
-    return NextResponse.json({ error: "Invalid request" }, { status: 400 })
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
   }
 }


### PR DESCRIPTION
## Description

The existing `lib/rate-limit.ts` was not wired into any route. This PR applies it to the two auth endpoints that are exposed to public traffic and vulnerable to brute force/enumeration attacks.

## Related Issue

Closes #179

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test addition/update

## Changes Made

- Applied IP-based rate limiting (10 req/min) to `POST /api/auth/challenge` via `checkRateLimit` + `getClientIp`
- Applied IP-based rate limiting (5 req/min) to `POST /api/auth/verify`
- Applied per-wallet rate limiting (5 req/min) to `POST /api/auth/verify` after the body is parsed and the address is validated
- Both return `429 Too Many Requests` with a `Retry-After` header when the limit is exceeded (behaviour already implemented in `lib/rate-limit.ts`)
- Added `__tests__/api/auth-challenge.test.ts` covering 429, Retry-After, and no false positives
- Added `__tests__/api/auth-verify.test.ts` covering IP limit exceeded, per-wallet limit exceeded, no false positives, and missing fields

## Checklist

- [x] My code follows the project's style guidelines (run `pnpm format`)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (57/57)

## Testing Instructions

1. Checkout this branch: `git checkout fix/179-rate-limit-auth-endpoints-v2`
2. Install dependencies: `pnpm install`
3. Run tests: `cd apps/web && pnpm test:api`
4. Verify all 57 tests pass, including the 7 new auth rate-limit tests

## For Bounty Issues

- [x] I have linked the bounty issue this PR resolves
- [x] All acceptance criteria from the issue are met
- [x] I have provided my Stellar address for bounty payout: `GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37`